### PR TITLE
Export 2019 03 05

### DIFF
--- a/locales/ace/app.po
+++ b/locales/ace/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-01-25 13:04+0000\n"
 "Last-Translator: haszalfin <haszalfin@gmail.com>\n"
 "Language: ace\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -140,6 +140,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Jaga Rahsia"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -159,6 +169,11 @@ msgstr "Sistem teutap"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Meusén mita teutap"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -448,6 +463,23 @@ msgid ""
 msgstr ""
 "Seumeulop hana euncit, tham alat seumeutöt wèb nyang biasa. Peuaman data "
 "peunténg droeneuh."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"

--- a/locales/ace/app.po
+++ b/locales/ace/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-01-25 13:04+0000\n"
 "Last-Translator: haszalfin <haszalfin@gmail.com>\n"
 "Language: ace\n"
@@ -140,11 +140,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Jaga Rahsia"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -469,16 +475,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/anp/app.po
+++ b/locales/anp/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-01-01 18:33+0000\n"
 "Last-Translator: Kumar Ritu Raj. <kumarrituraj2000@gmail.com>\n"
 "Language: anp\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,6 +139,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -158,6 +168,11 @@ msgstr "डिफ़ॉल्ट सिस्टम"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "डिफॉल्ट सर्च इंजन"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -443,6 +458,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/anp/app.po
+++ b/locales/anp/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-01-01 18:33+0000\n"
 "Last-Translator: Kumar Ritu Raj. <kumarrituraj2000@gmail.com>\n"
 "Language: anp\n"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -465,16 +471,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/bn-IN/app.po
+++ b/locales/bn-IN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-11-01 08:43+0000\n"
 "Last-Translator: Biraj  Karmakar <brnet00@gmail.com>\n"
 "Language: bn_IN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,6 +138,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "গোপনীয়তা সংক্রান্ত নীতি"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -157,6 +167,11 @@ msgstr "সিস্টেম ডিফল্ট"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "ডিফল্ট সার্চ ইঞ্জিন"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -446,6 +461,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/bn-IN/app.po
+++ b/locales/bn-IN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-11-01 08:43+0000\n"
 "Last-Translator: Biraj  Karmakar <brnet00@gmail.com>\n"
 "Language: bn_IN\n"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "গোপনীয়তা সংক্রান্ত নীতি"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -468,16 +474,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/gor/app.po
+++ b/locales/gor/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-11-08 12:28+0000\n"
 "Last-Translator: Marwan Mohamad <mar.one818@gmail.com>\n"
 "Language: gor\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,6 +139,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Tinepo Privasi"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -158,6 +168,11 @@ msgstr "Dudelo lo sistem"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Masina dudelo pololohu"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -443,6 +458,23 @@ msgid ""
 msgstr ""
 "Monguli'ato ja'o alupo wawu bubuli ngotayade damango alupo web lo'u "
 "layito. Pastiya amani lo data rahasia olemu. "
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"

--- a/locales/gor/app.po
+++ b/locales/gor/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-11-08 12:28+0000\n"
 "Last-Translator: Marwan Mohamad <mar.one818@gmail.com>\n"
 "Language: gor\n"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Tinepo Privasi"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -464,16 +470,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/gu-IN/app.po
+++ b/locales/gu-IN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-23 10:29+0000\n"
 "Last-Translator: Hariom Panchal <hariompanchal6647@hotmail.com>\n"
-"Language-Team: gu_IN <LL@li.org>\n"
 "Language: gu_IN\n"
+"Language-Team: gu_IN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,13 @@ msgstr "Firefox Lite માં શોધો"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s એ %2$s દ્વારા ઉત્પાદિત કરવામાં આવેલું ઝડપી અને ઓછી જગ્યા રોકે તેવું છે. અમારું લક્ષ્ય એક યોગ્ય , બધાં વાપરી શકે તેવું ઇન્ટરનેટ પ્રસ્થાપિત કરવાનું છે."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s એ %2$s દ્વારા ઉત્પાદિત કરવામાં આવેલું ઝડપી અને ઓછી જગ્યા રોકે તેવું "
+"છે. અમારું લક્ષ્ય એક યોગ્ય , બધાં વાપરી શકે તેવું ઇન્ટરનેટ પ્રસ્થાપિત "
+"કરવાનું છે."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +138,16 @@ msgstr "તમારા અધિકારો / પરવાનગીઓ"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ગોપનીયતા સૂચના"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +168,11 @@ msgstr "સિસ્ટમ મૂળભૂત"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "મૂળભૂત શોધ એંજીન"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +215,12 @@ msgstr "ઉપયોગ ડેટા મોકલો"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s માત્ર દરેકને માટે %1$s પ્રદાન અને સુધારવાની જરૂર છે તે એકત્રિત કરવાનો પ્રયત્ન કરે છે."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s માત્ર દરેકને માટે %1$s પ્રદાન અને સુધારવાની જરૂર છે તે એકત્રિત "
+"કરવાનો પ્રયત્ન કરે છે."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +330,12 @@ msgstr "એક એવી અૅપ શોધો કે જે લીંક ખ�
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "તમારા ઉપકરણ પરની કોઈપણ એપ્લિકેશનો આ લિંક ખોલવા માટે સક્ષમ નથી. તમે એપ્લિકેશન માટે %2$s શોધવા માટે %1$s કરી છોડી શકો છો."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"તમારા ઉપકરણ પરની કોઈપણ એપ્લિકેશનો આ લિંક ખોલવા માટે સક્ષમ નથી. તમે "
+"એપ્લિકેશન માટે %2$s શોધવા માટે %1$s કરી છોડી શકો છો."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -382,39 +409,75 @@ msgstr "%1$s પસંદગી માટે આભાર"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "%1$s દ્વારા ઇન્ડોનેશિયા માટે બનાવાયેલા એક બ્રાઉઝર, બિન નફાકારક એક મફત અને ખુલ્લા વેબ માટે પ્રતિબદ્ધ છે."
+msgstr ""
+"%1$s દ્વારા ઇન્ડોનેશિયા માટે બનાવાયેલા એક બ્રાઉઝર, બિન નફાકારક એક મફત અને"
+" ખુલ્લા વેબ માટે પ્રતિબદ્ધ છે."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "ક્યારેય કરતાં વધુ ઝડપી બ્રાઉઝ કરો"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "ટ્રેકિંગ જાહેરાતોને અવરોધિત કરવા ટર્બો મોડનો ઉપયોગ કરો કે જેનાથી તમે ખૂબ ઝડપથી બ્રાઉઝ કરી શકશો. જો વેબસાઉટમાં ભંગાણ દેખાય તો મેનુમાં જઇને ટર્બો મોડ બંધ કરો."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"ટ્રેકિંગ જાહેરાતોને અવરોધિત કરવા ટર્બો મોડનો ઉપયોગ કરો કે જેનાથી તમે ખૂબ "
+"ઝડપથી બ્રાઉઝ કરી શકશો. જો વેબસાઉટમાં ભંગાણ દેખાય તો મેનુમાં જઇને ટર્બો "
+"મોડ બંધ કરો."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "ડેટા બચાવો = પૈસા બચાવો"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "ટ્રેકિંગ જાહેરાતને અવરોધિત કરીને ડૅટા ખર્ચ બચાવો. છબીઓને અવરોધિત કરીને એનાથી પણ વધુ બચાવો."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"ટ્રેકિંગ જાહેરાતને અવરોધિત કરીને ડૅટા ખર્ચ બચાવો. છબીઓને અવરોધિત કરીને "
+"એનાથી પણ વધુ બચાવો."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "સમગ્ર પાનાંનો સ્ક્રીનશોટ લો"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "સમગ્ર પૃષ્ઠ સ્ક્રોલનું સ્ક્રીનશોટ લો. ડેટાનો ઉપયોગ કર્યા વિના તેને ઑફલાઇન વાંચો અથવા વેબ પૃષ્ઠ પર ફરીથી મુલાકાત લેવા તે દબાવો."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"સમગ્ર પૃષ્ઠ સ્ક્રોલનું સ્ક્રીનશોટ લો. ડેટાનો ઉપયોગ કર્યા વિના તેને ઑફલાઇન"
+" વાંચો અથવા વેબ પૃષ્ઠ પર ફરીથી મુલાકાત લેવા તે દબાવો."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "આગળની કક્ષાની ગોપનીયતા"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "ટ્રેસ વિના બ્રાઉઝ કરો અને ડિફૉલ્ટ રૂપે સામાન્ય વેબ ટ્રેકર્સની વિશાળ શ્રેણીને અવરોધિત કરો. તમારા ગોપનીય ડેટાની સુરક્ષાની ખાતરી કરો."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"ટ્રેસ વિના બ્રાઉઝ કરો અને ડિફૉલ્ટ રૂપે સામાન્ય વેબ ટ્રેકર્સની વિશાળ "
+"શ્રેણીને અવરોધિત કરો. તમારા ગોપનીય ડેટાની સુરક્ષાની ખાતરી કરો."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +490,12 @@ msgstr "અમારી પાસે એક નવો દેખાવ છે!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "વિકસિત ઉત્પાદન સાથે, અમે તમારી માટે નવાં નામ અને નવાં લોગો સાથે નવું તાજું %1$s લાવીએ છીએ."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"વિકસિત ઉત્પાદન સાથે, અમે તમારી માટે નવાં નામ અને નવાં લોગો સાથે નવું "
+"તાજું %1$s લાવીએ છીએ."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,8 +615,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "સ્થાન ઉપલબ્ધ નથી. તમારા સ્થાનને ઍક્સેસ કરવાની પરવાનગી આપો."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "સંગ્રહ ઉપલબ્ધ નથી. તમારા ઉપકરણ પર ફોટા અને ફાઇલોને સંગ્રહિત કરવાની પરવાનગી આપો."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"સંગ્રહ ઉપલબ્ધ નથી. તમારા ઉપકરણ પર ફોટા અને ફાઇલોને સંગ્રહિત કરવાની "
+"પરવાનગી આપો."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -932,8 +1003,12 @@ msgid "Product Update Notice"
 msgstr "ઉત્પાદન અધ્યતન બનાવવાની સૂચના"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Firefox Lite ને તમારાં માટે અને બીજા બધાં માટે વધુ સારુ બનાવવા, અમે ખાનગી પાૅલીસિમાં અમુક સુધારા કરેલ છે. વધું જાણવાં માટે આ દબાવો."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Firefox Lite ને તમારાં માટે અને બીજા બધાં માટે વધુ સારુ બનાવવા, અમે ખાનગી"
+" પાૅલીસિમાં અમુક સુધારા કરેલ છે. વધું જાણવાં માટે આ દબાવો."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -945,7 +1020,9 @@ msgstr "%1$s ગમ્યું?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "અમારું ઉત્પાદન પસંદ કરવા બદલ આપનો આભાર. તમારો અભિપ્રાય અમારી માટે મહત્વનો છે."
+msgstr ""
+"અમારું ઉત્પાદન પસંદ કરવા બદલ આપનો આભાર. તમારો અભિપ્રાય અમારી માટે મહત્વનો"
+" છે."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -990,21 +1067,29 @@ msgstr "વહેંચો"
 #, c-format
 msgctxt "share_app_promotion_text"
 msgid "Hey, check out this fast and lightweight browser from %3$s. %1$s %2$s"
-msgstr "%3$s દ્વારા બનાવવામાં આવેલું ઝડપી અને ઓછી જગ્યા રોકે તેવું આ બ્રાઉઝર જુઓ. %1$s %2$s"
+msgstr ""
+"%3$s દ્વારા બનાવવામાં આવેલું ઝડપી અને ઓછી જગ્યા રોકે તેવું આ બ્રાઉઝર જુઓ."
+" %1$s %2$s"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s %2$s અને અન્ય યોગદાનકર્તાઓ દ્વારા બનાવવામાં આવેલ મફત અને ઓપન સોર્સ સૉફ્ટવેર છે."
+msgstr ""
+"%1$s %2$s અને અન્ય યોગદાનકર્તાઓ દ્વારા બનાવવામાં આવેલ મફત અને ઓપન સોર્સ "
+"સૉફ્ટવેર છે."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s એ <a href=\"%2$s\">%3$s સાર્વજનિક પરવાનગીની શરતો પર</a> અને બીજી ઓપનસોર્સ પરવાનગીનાં આધાર પર તમારાં માટે ઉપ્લબ્ધ કરવામાં આવેલ છે."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s એ <a href=\"%2$s\">%3$s સાર્વજનિક પરવાનગીની શરતો પર</a> અને બીજી "
+"ઓપનસોર્સ પરવાનગીનાં આધાર પર તમારાં માટે ઉપ્લબ્ધ કરવામાં આવેલ છે."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1013,16 +1098,24 @@ msgstr "%1$s એ <a href=\"%2$s\">%3$s સાર્વજનિક પરવા�
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
-msgstr "તમને %3$s ફાઉન્ડેશન અથવા અન્ય કોઇ પક્ષ, Mozilla, %4$s કે %1$s નામ અથવા લોગો સહિતનાં વ્યાપાર ચિહ્નનાં કોઇ અધિકાર કે પરવાનગી આપવામાં આવેલ નથી. વધારાની માહિતી <a href=\"%2$s\">અહિંયા મળશે</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
+msgstr ""
+"તમને %3$s ફાઉન્ડેશન અથવા અન્ય કોઇ પક્ષ, Mozilla, %4$s કે %1$s નામ અથવા "
+"લોગો સહિતનાં વ્યાપાર ચિહ્નનાં કોઇ અધિકાર કે પરવાનગી આપવામાં આવેલ નથી. "
+"વધારાની માહિતી <a href=\"%2$s\">અહિંયા મળશે</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "બીજા વિભિન્ન પ્રકારનાં નિઃશુલ્ક અને ઓપન સોર્સ<a href=\"%2$s\">ની પરવાનગી હેઠળ</a>%1$s માટે વધારાનાં સોર્સ કોડ ઉપ્લબ્ધ છે."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"બીજા વિભિન્ન પ્રકારનાં નિઃશુલ્ક અને ઓપન સોર્સ<a href=\"%2$s\">ની પરવાનગી "
+"હેઠળ</a>%1$s માટે વધારાનાં સોર્સ કોડ ઉપ્લબ્ધ છે."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1030,10 +1123,14 @@ msgstr "બીજા વિભિન્ન પ્રકારનાં નિઃ
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s એ Disconnect, Inc. દ્વારા આપવામાં આવેલ બ્લોકલિસ્ટનો ઉપયોગ પણ કરે છે કે જે <a href=\"%2$s\">GNU જનરલ પબ્લિક લાયસેંસ v3</a>,હેઠળ અલગથી અને સ્વતન્તર રીતે કામ કરે છે, અને અહિંયા <a "
-"href=\"%3$s\">ઉપ્લબ્ધ છે</a>."
+"%1$s એ Disconnect, Inc. દ્વારા આપવામાં આવેલ બ્લોકલિસ્ટનો ઉપયોગ પણ કરે છે "
+"કે જે <a href=\"%2$s\">GNU જનરલ પબ્લિક લાયસેંસ v3</a>,હેઠળ અલગથી અને "
+"સ્વતન્તર રીતે કામ કરે છે, અને અહિંયા <a href=\"%3$s\">ઉપ્લબ્ધ છે</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1203,26 +1300,36 @@ msgstr "તમારા સ્ક્રીનશોટ અહીં જુઓ!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "તમારાં ઉત્પાદનનો અનુભવ સુધારવાં માટે, અમે તમારાં સ્ક્રીનશોટનાં વર્ગો વિશે માહિતી ભેગી કરીએ છીએ."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"તમારાં ઉત્પાદનનો અનુભવ સુધારવાં માટે, અમે તમારાં સ્ક્રીનશોટનાં વર્ગો વિશે"
+" માહિતી ભેગી કરીએ છીએ."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "7-દિવસની મફત VPN સેવા તમારા માટે તૈયાર છે. વધુ ખાનગી અને સુરક્ષિત રીતે બ્રાઉઝ કરવા માટે હમણાં ઇન્સ્ટોલ કરો."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"7-દિવસની મફત VPN સેવા તમારા માટે તૈયાર છે. વધુ ખાનગી અને સુરક્ષિત રીતે "
+"બ્રાઉઝ કરવા માટે હમણાં ઇન્સ્ટોલ કરો."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"અમે નજીકમાં ગુણવત્તાયુક્ત મફત ઇન્ટરનેટ કનેક્શન શોધવામાં તમારી સહાય માટે “મફત Wifi-Finder” ની સંકલન કરવાની યોજના બનાવી છે.\n"
+"અમે નજીકમાં ગુણવત્તાયુક્ત મફત ઇન્ટરનેટ કનેક્શન શોધવામાં તમારી સહાય માટે "
+"“મફત Wifi-Finder” ની સંકલન કરવાની યોજના બનાવી છે.\n"
 "\n"
 " શું તમે રસ ધરાવો છો?"
 
@@ -1231,11 +1338,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"બ્રાઉઝ કરતી વખતે તમને વધુ સ્વતંત્રતા અને વધુ ગોપનીયતા મેળવવા માટે અમે “VPN સેવા” ને એકીકૃત કરવા માંગીએ છીએ.\n"
+"બ્રાઉઝ કરતી વખતે તમને વધુ સ્વતંત્રતા અને વધુ ગોપનીયતા મેળવવા માટે અમે "
+"“VPN સેવા” ને એકીકૃત કરવા માંગીએ છીએ.\n"
 "\n"
 "શું તમે રસ ધરાવો છો?"
 
@@ -1257,3 +1366,4 @@ msgstr "હા, કૃપા કરીને"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "ના"
+

--- a/locales/gu-IN/app.po
+++ b/locales/gu-IN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-23 10:29+0000\n"
 "Last-Translator: Hariom Panchal <hariompanchal6647@hotmail.com>\n"
 "Language: gu_IN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ગોપનીયતા સૂચના"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -467,16 +473,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/hi-IN/app.po
+++ b/locales/hi-IN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-26 05:00+0000\n"
 "Last-Translator: Mahtab Alam <mahtab.ceh@gmail.com>\n"
-"Language-Team: hi_IN <LL@li.org>\n"
 "Language: hi_IN\n"
+"Language-Team: hi_IN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "Firefox Lite में खोजें"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s %2$s द्वारा निर्मित तीव्र एवं हल्का ब्राउज़र है। हमारा लक्ष्य एक स्वस्थ, मुक्त इंटरनेट को बढ़ावा देना है।"
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s %2$s द्वारा निर्मित तीव्र एवं हल्का ब्राउज़र है। हमारा लक्ष्य एक "
+"स्वस्थ, मुक्त इंटरनेट को बढ़ावा देना है।"
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "आपका अधिकार / लाइसेंस"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "सिस्टम तयशुदा"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "तयशुदा खोज इंजन"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "उपयोग डेटा भेजें"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s मात्र वही जानकारी एकत्र करने का प्रयास करता है जिससे हम %1$s को सभी के लिए उपलब्ध तथा बेहतर बना सकें।"
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s मात्र वही जानकारी एकत्र करने का प्रयास करता है जिससे हम %1$s को सभी "
+"के लिए उपलब्ध तथा बेहतर बना सकें।"
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "लिंक खोलने हेतु कोई ऐप तलाश�
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "आपके उपकरण पर कोई भी ऐप इस लिंक को खोलने में सक्षम नहीं हैं।आप %2$s को खोजने हेतु एक ऐप के लिए %1$s को छोड़ सकते हैं जो कर सकता हैं।"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"आपके उपकरण पर कोई भी ऐप इस लिंक को खोलने में सक्षम नहीं हैं।आप %2$s को "
+"खोजने हेतु एक ऐप के लिए %1$s को छोड़ सकते हैं जो कर सकता हैं।"
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -333,7 +359,9 @@ msgstr "पता समझा नहीं गया था"
 
 msgctxt "error_page_content_text_unsupported_scheme"
 msgid "You might need to install other software to open this address."
-msgstr "इस पते को खोलने हेतु आपको अन्य सॉफ़्टवेयर संस्थापित करने की आवश्यकता हो सकती है।"
+msgstr ""
+"इस पते को खोलने हेतु आपको अन्य सॉफ़्टवेयर संस्थापित करने की आवश्यकता हो "
+"सकती है।"
 
 #. Label used in the contextmenu shown when long-pressing on a link
 msgctxt "contextmenu_link_share"
@@ -382,39 +410,76 @@ msgstr "%1$s चुनने के लिए धन्यवाद"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "गैर-लाभकारी %1$s द्वारा निर्मित एक ब्राउज़र, एक मुफ्त तथा खुले वेब के लिए समर्पित।"
+msgstr ""
+"गैर-लाभकारी %1$s द्वारा निर्मित एक ब्राउज़र, एक मुफ्त तथा खुले वेब के लिए "
+"समर्पित।"
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "पहले से तेज ब्राउज़ करें"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "ट्रैकिंग विज्ञापनों को ब्लॉक करने के लिए टर्बो प्रणाली का उपयोग करें ताकि आप तेज गति से ब्राउज़ कर सकें। यदि साइटें टूटी लगती हैं, तो विकल्प सूची में टर्बो मोड बटन को दबाएँ।"
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"ट्रैकिंग विज्ञापनों को ब्लॉक करने के लिए टर्बो प्रणाली का उपयोग करें ताकि"
+" आप तेज गति से ब्राउज़ कर सकें। यदि साइटें टूटी लगती हैं, तो विकल्प सूची "
+"में टर्बो मोड बटन को दबाएँ।"
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "डेटा बचाएँ = पैसे बचाएँ"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "ट्रैकिंग विज्ञापनों को ब्लॉक कर डेटा लागत बचाएँ। चित्र ब्लॉकिंग सक्षम कर और भी अधिक डेटा बचाएँ।"
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"ट्रैकिंग विज्ञापनों को ब्लॉक कर डेटा लागत बचाएँ। चित्र ब्लॉकिंग सक्षम कर "
+"और भी अधिक डेटा बचाएँ।"
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "पूर्ण पृष्ठ का स्क्रीनशॉट लें"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "पूर्ण पृष्ठ का स्क्रीनशॉट लें। डेटा इस्तेमाल किये बिना इसे ऑफलाइन पढ़ें या वेब पृष्ठ पर दुबारा जाने के लिए इसे टैप करें।"
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"पूर्ण पृष्ठ का स्क्रीनशॉट लें। डेटा इस्तेमाल किये बिना इसे ऑफलाइन पढ़ें या"
+" वेब पृष्ठ पर दुबारा जाने के लिए इसे टैप करें।"
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "अगले-दर्जे की गोपनीयता"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "बिना ट्रेस हुए ब्राउज़ करें, और डिफ़ॉल्ट रूप से आम वेब ट्रैकर्स की एक विस्तृत श्रृंखला को ब्लॉक करें। अपने गोपनीय डेटा की सुरक्षा सुनिश्चित करें।"
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"बिना ट्रेस हुए ब्राउज़ करें, और डिफ़ॉल्ट रूप से आम वेब ट्रैकर्स की एक "
+"विस्तृत श्रृंखला को ब्लॉक करें। अपने गोपनीय डेटा की सुरक्षा सुनिश्चित "
+"करें।"
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +492,12 @@ msgstr "हमारे पास एक नया लुक है!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "विकसित प्रोडक्ट के साथ, एक नए नाम और नए लोगो के साथ, हम आपके लिए बिलकुल नया %1$s लाये हैं।"
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"विकसित प्रोडक्ट के साथ, एक नए नाम और नए लोगो के साथ, हम आपके लिए बिलकुल "
+"नया %1$s लाये हैं।"
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,8 +617,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "स्थान उपलब्ध नहीं है। अपने स्थान तक पहुँचने के लिए अनुमति दें।"
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "संग्रहण उपलब्ध नहीं है। अपने डिवाइस पर फ़ोटो और फ़ाइलें संग्रहीत करने की अनुमति दें।"
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"संग्रहण उपलब्ध नहीं है। अपने डिवाइस पर फ़ोटो और फ़ाइलें संग्रहीत करने की "
+"अनुमति दें।"
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -934,8 +1007,12 @@ msgid "Product Update Notice"
 msgstr "प्रोडक्ट अद्यतन सूचना"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Firefox Lite को आपके और हर किसी के लिए बेहतर बनाने के लिए, हमने अपनी गोपनीयता नीति में कुछ बदलाव किए हैं। अधिक जानने के लिए दबाएँ।"
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Firefox Lite को आपके और हर किसी के लिए बेहतर बनाने के लिए, हमने अपनी "
+"गोपनीयता नीति में कुछ बदलाव किए हैं। अधिक जानने के लिए दबाएँ।"
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -947,7 +1024,9 @@ msgstr "%1$s पसंद आया?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "हमारे प्रोडक्ट को चुनने के लिए धन्यवाद। आपकी प्रतिक्रिया हमारे लिए महत्वपूर्ण है।"
+msgstr ""
+"हमारे प्रोडक्ट को चुनने के लिए धन्यवाद। आपकी प्रतिक्रिया हमारे लिए "
+"महत्वपूर्ण है।"
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -992,21 +1071,29 @@ msgstr "साझा करें"
 #, c-format
 msgctxt "share_app_promotion_text"
 msgid "Hey, check out this fast and lightweight browser from %3$s. %1$s %2$s"
-msgstr "सुनो, %3$s द्वारा निर्मित तीव्र तथा एवं हलके ब्राउज़र का जायजा लें। %1$s %2$s"
+msgstr ""
+"सुनो, %3$s द्वारा निर्मित तीव्र तथा एवं हलके ब्राउज़र का जायजा लें। %1$s "
+"%2$s"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s %2$s तथा अन्य योगदानकर्ताओं द्वारा निर्मित मुफ्त एवं ओपन सोर्स सॉफ्टवेयर है।"
+msgstr ""
+"%1$s %2$s तथा अन्य योगदानकर्ताओं द्वारा निर्मित मुफ्त एवं ओपन सोर्स "
+"सॉफ्टवेयर है।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s <a href=\"%2$s\">%3$s</a> तथा अन्य ओपन सोर्स लाइसेंस की शर्तों के तहत आपके लिए उपलब्ध कराया जाता है।"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s <a href=\"%2$s\">%3$s</a> तथा अन्य ओपन सोर्स लाइसेंस की शर्तों के "
+"तहत आपके लिए उपलब्ध कराया जाता है।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1015,18 +1102,24 @@ msgstr "%1$s <a href=\"%2$s\">%3$s</a> तथा अन्य ओपन सो�
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"Mozilla फ़ाउंडेशन या किसी भी पार्टी के ट्रेडमार्क साथ ही %3$s, %4$s या %1$s के नाम अथवा लोगो, के लिए कोई अधिकार या लाइसेंस आपको नहीं दिया जाता है। अधिक जानकारी <a href=\"%2$s\">यहाँ</a> से पा सकते "
-"हैं।"
+"Mozilla फ़ाउंडेशन या किसी भी पार्टी के ट्रेडमार्क साथ ही %3$s, %4$s या "
+"%1$s के नाम अथवा लोगो, के लिए कोई अधिकार या लाइसेंस आपको नहीं दिया जाता "
+"है। अधिक जानकारी <a href=\"%2$s\">यहाँ</a> से पा सकते हैं।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s के लिए अतिरिक्त स्रोत कोड विभिन्न अन्य मुफ़्त और ओपन सोर्स <a href=\"%2$s\">लायसेंस</a> के तहत उपलब्ध है। "
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s के लिए अतिरिक्त स्रोत कोड विभिन्न अन्य मुफ़्त और ओपन सोर्स <a "
+"href=\"%2$s\">लायसेंस</a> के तहत उपलब्ध है। "
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1034,10 +1127,14 @@ msgstr "%1$s के लिए अतिरिक्त स्रोत कोड
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s Disconnect, Inc. द्वारा प्रदान की गई ब्लॉकलिस्ट का भी उपयोग करता है जो <a href=\"%2$s\">जीएनयू सामान्य लोक लायसेंस v3</a> के तहत अलग और स्वतंत्र काम करता है, और <a href=\"%3$s\">यहाँ</a> उपलब्ध"
-" है।"
+"%1$s Disconnect, Inc. द्वारा प्रदान की गई ब्लॉकलिस्ट का भी उपयोग करता है "
+"जो <a href=\"%2$s\">जीएनयू सामान्य लोक लायसेंस v3</a> के तहत अलग और "
+"स्वतंत्र काम करता है, और <a href=\"%3$s\">यहाँ</a> उपलब्ध है।"
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1209,26 +1306,36 @@ msgstr "अपने स्क्रीनशॉटों को यहाँ �
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "आपके प्रोडक्ट अनुभव को सुधारने के लिए, हम आपके स्क्रीनशॉट श्रेणियों के बारे में जानकारियाँ जमा करते हैं।"
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"आपके प्रोडक्ट अनुभव को सुधारने के लिए, हम आपके स्क्रीनशॉट श्रेणियों के "
+"बारे में जानकारियाँ जमा करते हैं।"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "7-दिनों की निःशुल्क VPN सेवा आपके लिए तैयार है। और भी अधिक निजी एवं सुरक्षित रूप से ब्राउज करने हेतु अभी इनस्टॉल करें।"
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"7-दिनों की निःशुल्क VPN सेवा आपके लिए तैयार है। और भी अधिक निजी एवं "
+"सुरक्षित रूप से ब्राउज करने हेतु अभी इनस्टॉल करें।"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"हम “मुफ्त वाईफाई-खोजक” जोड़ने पर विचार कर रहे हैं ताकि आपको आसपास अच्छी मुफ्त इंटरनेट कनेक्शन खोजने में मदद कर सकें।\n"
+"हम “मुफ्त वाईफाई-खोजक” जोड़ने पर विचार कर रहे हैं ताकि आपको आसपास अच्छी "
+"मुफ्त इंटरनेट कनेक्शन खोजने में मदद कर सकें।\n"
 " \n"
 " इच्छुक हैं?"
 
@@ -1237,11 +1344,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"हम “VPN सेवा” जोड़ने पर विचार कर रहे हैं ताकि आपको ब्राउज़िंग करते समय अधिक आजादी एवं अधिक गोपनीयता मिल सके।\n"
+"हम “VPN सेवा” जोड़ने पर विचार कर रहे हैं ताकि आपको ब्राउज़िंग करते समय अधिक"
+" आजादी एवं अधिक गोपनीयता मिल सके।\n"
 " \n"
 " इच्छुक हैं?"
 
@@ -1263,3 +1372,4 @@ msgstr "YES, PLEASE"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "NOPE"
+

--- a/locales/hi-IN/app.po
+++ b/locales/hi-IN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-26 05:00+0000\n"
 "Last-Translator: Mahtab Alam <mahtab.ceh@gmail.com>\n"
 "Language: hi_IN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -469,16 +475,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/id/app.po
+++ b/locales/id/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-22 03:10+0000\n"
 "Last-Translator: Fauzan Alfi <fauzanalfi@mozilla.web.id>\n"
-"Language-Team: id <LL@li.org>\n"
 "Language: id\n"
+"Language-Team: id <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "Cari di Firefox Lite"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s adalah sebuah peramban cepat dan ringan buatan %2$s. Misi kami adalah untuk mendorong internet yang sehat dan terbuka."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s adalah sebuah peramban cepat dan ringan buatan %2$s. Misi kami "
+"adalah untuk mendorong internet yang sehat dan terbuka."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "Hak / Izin Anda"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Kebijakan Privasi"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "Bawaan sistem"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Mesin pencari baku"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "Kirim data penggunaan"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s hanya akan mengumpulkan data yang diperlukan saja untuk memperbaiki %1$s bagi Anda."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s hanya akan mengumpulkan data yang diperlukan saja untuk memperbaiki "
+"%1$s bagi Anda."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "Cari aplikasi yang bisa membuka tautan"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Tak ada satu pun aplikasi di perangkat Anda dapat membuka tautan ini. Anda dapat meninggalkan %1$s untuk mencari aplikasi yang mampu di %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Tak ada satu pun aplikasi di perangkat Anda dapat membuka tautan ini. "
+"Anda dapat meninggalkan %1$s untuk mencari aplikasi yang mampu di %2$s."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -382,39 +408,75 @@ msgstr "Terima kasih telah memilih %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "Peramban yang dibuat oleh %1$s, organisasi nirlaba yang berkomitmen pada web bebas dan terbuka."
+msgstr ""
+"Peramban yang dibuat oleh %1$s, organisasi nirlaba yang berkomitmen pada "
+"web bebas dan terbuka."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "Menjelajah secepat kilat"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "Gunakan mode turbo untuk memblokir iklan pelacak sehingga Anda dapat menjelajah dengan super cepat. Jika situs terasa bermasalah, cukup nonaktifkan lewat menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"Gunakan mode turbo untuk memblokir iklan pelacak sehingga Anda dapat "
+"menjelajah dengan super cepat. Jika situs terasa bermasalah, cukup "
+"nonaktifkan lewat menu."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "Hemat data = Hemat uang"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "Hemat kuota data dengan memblokir iklan berpelacak. Lebih hemat lagi saat Anda aktifkan pemblokir gambar."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"Hemat kuota data dengan memblokir iklan berpelacak. Lebih hemat lagi saat"
+" Anda aktifkan pemblokir gambar."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "Cuplik keseluruhan layar"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "Cuplik layar keseluruhan penggeseran layar. Baca secara luring tanpa kuota data atau ketuk untuk mengunjungi laman Web tersebut."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"Cuplik layar keseluruhan penggeseran layar. Baca secara luring tanpa "
+"kuota data atau ketuk untuk mengunjungi laman Web tersebut."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "Privasi tingkat selanjutnya"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "Jelajahi tanpa pelacak dan blokir sebagian besar pelacak web secara baku. Pastikan keamanan data rahasia Anda."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"Jelajahi tanpa pelacak dan blokir sebagian besar pelacak web secara baku."
+" Pastikan keamanan data rahasia Anda."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +489,12 @@ msgstr "Tampilan baru!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "Melalui evolusi produk, kami hadirkan %1$s yang segar, dengan nama dan logo baru."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"Melalui evolusi produk, kami hadirkan %1$s yang segar, dengan nama dan "
+"logo baru."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,8 +614,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "Lokasi tidak tersedia. Izinkan agar aplikasi bisa mengakses lokasi Anda."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "Penyimpanan tidak tersedia. Izinkan agar aplikasi bisa menyimpan foto dan berkas pada peranti Anda."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"Penyimpanan tidak tersedia. Izinkan agar aplikasi bisa menyimpan foto dan"
+" berkas pada peranti Anda."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -936,8 +1006,13 @@ msgid "Product Update Notice"
 msgstr "Pemberitahuan Pembaruan Produk"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Untuk membuat Firefox Lite lebih baik untuk Anda dan setiap orang, kami membuat beberapa perubahan pada kebijakan privasi kami. Ketuk untuk mempelajari lebih lanjut."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Untuk membuat Firefox Lite lebih baik untuk Anda dan setiap orang, kami "
+"membuat beberapa perubahan pada kebijakan privasi kami. Ketuk untuk "
+"mempelajari lebih lanjut."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -949,7 +1024,9 @@ msgstr "Suka %1$s?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "Terima kasih telah memilih produk kami. Masukan Anda sangat penting bagi kami."
+msgstr ""
+"Terima kasih telah memilih produk kami. Masukan Anda sangat penting bagi "
+"kami."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -1000,15 +1077,21 @@ msgstr "Yuk, coba peramban cepat dan ringan dari %3$s. %1$s %2$s"
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s adalah perangkat lunak bebas dan sumber terbuka yang dibuat oleh %2$s dan kontributor lainnya."
+msgstr ""
+"%1$s adalah perangkat lunak bebas dan sumber terbuka yang dibuat oleh "
+"%2$s dan kontributor lainnya."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s tersedia untuk Anda di bawah persyaratan <a href=\"%2$s\">%3$s</a> dan lisensi sumber terbuka lainnya."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s tersedia untuk Anda di bawah persyaratan <a href=\"%2$s\">%3$s</a> "
+"dan lisensi sumber terbuka lainnya."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1017,18 +1100,24 @@ msgstr "%1$s tersedia untuk Anda di bawah persyaratan <a href=\"%2$s\">%3$s</a> 
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"Anda tidak diberi izin atau lisensi apa pun atas merek dagang Mozilla Foundation atau pihak mana pun, termasuk nama atau logo %3$s, %4$s, atau %1$s. Informasi lebih lanjut bisa ditemukan <a "
-"href=\"%2$s\">di sini</a>."
+"Anda tidak diberi izin atau lisensi apa pun atas merek dagang Mozilla "
+"Foundation atau pihak mana pun, termasuk nama atau logo %3$s, %4$s, atau "
+"%1$s. Informasi lebih lanjut bisa ditemukan <a href=\"%2$s\">di sini</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Kode sumber tambahan untuk %1$s tersedia dalam berbagai <a href=\"%2$s\">lisensi</a> bebas dan sumber terbuka lainnya."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Kode sumber tambahan untuk %1$s tersedia dalam berbagai <a "
+"href=\"%2$s\">lisensi</a> bebas dan sumber terbuka lainnya."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1036,9 +1125,14 @@ msgstr "Kode sumber tambahan untuk %1$s tersedia dalam berbagai <a href=\"%2$s\"
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s juga menggunakan daftar blokir yang disediakan oleh Disconnect, Inc. sebagai hasil karya terpisah dan independen di bawah <a href=\"%2$s\">GNU General Public License v3</a>, dan tersedia <a "
+"%1$s juga menggunakan daftar blokir yang disediakan oleh Disconnect, Inc."
+" sebagai hasil karya terpisah dan independen di bawah <a "
+"href=\"%2$s\">GNU General Public License v3</a>, dan tersedia <a "
 "href=\"%3$s\">di sini</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
@@ -1211,26 +1305,36 @@ msgstr "Lihat cuplikan layar Anda di sini!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "Untuk meningkatkan pengalaman produk, kami mengumpulkan informasi tentang kategori cuplikan layar Anda."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"Untuk meningkatkan pengalaman produk, kami mengumpulkan informasi tentang"
+" kategori cuplikan layar Anda."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "Layanan VPN gratis selama 7 hari telah tersedia untuk Anda. Pasang sekarang untuk menjelajah lebih privat dan aman."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"Layanan VPN gratis selama 7 hari telah tersedia untuk Anda. Pasang "
+"sekarang untuk menjelajah lebih privat dan aman."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Rencana kami adalah untuk mengintegrasikan “Pencarian Wifi Gratis” untuk membantu Anda temukan koneksi Internet berkualitas gratis terdekat.\n"
+"Rencana kami adalah untuk mengintegrasikan “Pencarian Wifi Gratis” untuk "
+"membantu Anda temukan koneksi Internet berkualitas gratis terdekat.\n"
 "\n"
 " Tertarik?"
 
@@ -1239,11 +1343,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Rencana kami adalah mengintegrasikan \"Layanan VPN\" supaya Anda dapat kebebasan dan privasi lebih banyak saat menjelajah.\n"
+"Rencana kami adalah mengintegrasikan \"Layanan VPN\" supaya Anda dapat "
+"kebebasan dan privasi lebih banyak saat menjelajah.\n"
 "\n"
 " Tertarik?"
 
@@ -1265,3 +1371,4 @@ msgstr "YA"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "TIDAK"
+

--- a/locales/id/app.po
+++ b/locales/id/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-22 03:10+0000\n"
 "Last-Translator: Fauzan Alfi <fauzanalfi@mozilla.web.id>\n"
 "Language: id\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Kebijakan Privasi"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -466,16 +472,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/jv/app.po
+++ b/locales/jv/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-01-20 12:57+0000\n"
 "Last-Translator: Ringgo <armen.ringgo@yahoo.de>\n"
 "Language: jv\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,6 +139,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Pratélan Wadi"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -158,6 +168,11 @@ msgstr "Gawan sistem"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Mesin panggolèk standar"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -447,6 +462,23 @@ msgid ""
 msgstr ""
 "Delajah tanpa tilak, lan blokir sawetara pelacak web. Jamin keamanan data"
 " pribadimu."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"

--- a/locales/jv/app.po
+++ b/locales/jv/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-01-20 12:57+0000\n"
 "Last-Translator: Ringgo <armen.ringgo@yahoo.de>\n"
 "Language: jv\n"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Pratélan Wadi"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -468,16 +474,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/kn/app.po
+++ b/locales/kn/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-11-05 14:36+0000\n"
 "Last-Translator: Omshivaprakash H L <omshivaprakash@gmail.com>\n"
 "Language: kn\n"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ಗೌಪ್ಯತಾ ಸೂಚನೆ"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -467,16 +473,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/kn/app.po
+++ b/locales/kn/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-11-05 14:36+0000\n"
 "Last-Translator: Omshivaprakash H L <omshivaprakash@gmail.com>\n"
 "Language: kn\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,6 +138,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ಗೌಪ್ಯತಾ ಸೂಚನೆ"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -157,6 +167,11 @@ msgstr "ವ್ಯವಸ್ಥೆಯ ಪೂರ್ವನಿಯೋಜಿತ"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಹುಡುಕು ಎಂಜಿನ್"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -446,6 +461,23 @@ msgstr ""
 "ಜಾಡು ಹಿಡಿಯಲಾಗದಂತೆ ಬ್ರೌಸ್ ಮಾಡಿ, ಮತ್ತು ವ್ಯಾಪಕವಾದ ಸಾಮಾನ್ಯ ವೆಬ್ "
 "ಟ್ರ್ಯಾಕರ್ಗಳನ್ನು ಪೂರ್ವನಿಯೋಜಿತವಾಗಿ ನಿರ್ಬಂಧಿಸಿ. ನಿಮ್ಮ ಗೌಪ್ಯ ದತ್ತಾಂಶದ "
 "ಭದ್ರತೆಯನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"

--- a/locales/mai/app.po
+++ b/locales/mai/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-08-08 01:02+0000\n"
 "Last-Translator: delphine <dlebedel@mozilla.com>\n"
 "Language: mai\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -140,6 +140,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -159,6 +169,11 @@ msgstr "सिस्टम डिफॉल्ट"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "डिफॉल्ट खोज इंजिन"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -446,6 +461,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/mai/app.po
+++ b/locales/mai/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-08-08 01:02+0000\n"
 "Last-Translator: delphine <dlebedel@mozilla.com>\n"
 "Language: mai\n"
@@ -140,11 +140,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -468,16 +474,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/ml/app.po
+++ b/locales/ml/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-10-06 13:57+0000\n"
 "Last-Translator: asdofindia <asdofindia@gmail.com>\n"
 "Language: ml\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,6 +139,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "സ്വകാര്യതാ അറിയിപ്പ്"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -158,6 +168,11 @@ msgstr "സിസ്റ്റത്തിൽ സ്വതവേയുള്ള�
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "സ്വതവേയുള്ള സെര്‍ച്ച് എഞ്ചിന്‍"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -448,6 +463,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/ml/app.po
+++ b/locales/ml/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-10-06 13:57+0000\n"
 "Last-Translator: asdofindia <asdofindia@gmail.com>\n"
 "Language: ml\n"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "സ്വകാര്യതാ അറിയിപ്പ്"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -470,16 +476,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/mr/app.po
+++ b/locales/mr/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-20 06:18+0000\n"
 "Last-Translator: narendrapetkar <n.v.petkar@gmail.com>\n"
 "Language: mr\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -466,16 +472,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/mr/app.po
+++ b/locales/mr/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-20 06:18+0000\n"
 "Last-Translator: narendrapetkar <n.v.petkar@gmail.com>\n"
-"Language-Team: mr <LL@li.org>\n"
 "Language: mr\n"
+"Language-Team: mr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "Firefox Lite मध्ये शोधा"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%2$s द्वारे तयार केलेला %1$s हा एक जलद आणि उज्वल ब्राउझर आहे. आमचे ध्येय निरोगी , सर्व-वापरण्यायोग्य इंटरनेट स्थापित करणे आहे."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%2$s द्वारे तयार केलेला %1$s हा एक जलद आणि उज्वल ब्राउझर आहे. आमचे ध्येय "
+"निरोगी , सर्व-वापरण्यायोग्य इंटरनेट स्थापित करणे आहे."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "आपले अधिकार / परवाने"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "गोपनीयता सूचना"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "पूर्वनिर्धारीत प्रणाली"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "पूर्वनिर्धारित शोध इंजिन"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "वापर डेटा पाठवा"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s सर्वांसाठी फक्त %1$s उपलब्ध करून सुधारण्यासाठी जी माहिती लागते ती जमवते."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s सर्वांसाठी फक्त %1$s उपलब्ध करून सुधारण्यासाठी जी माहिती लागते ती "
+"जमवते."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "लिंक उघडू शकतो असा एक अॅप शो
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "आपल्या उपकरणावरील कोणतेही अँप ही दुआ उघडू शकत नाहीत. आपण %1$s सोडून %2$s मध्ये आवश्यक अँप शोधण्यासाठी जाऊ शकता."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"आपल्या उपकरणावरील कोणतेही अँप ही दुआ उघडू शकत नाहीत. आपण %1$s सोडून %2$s "
+"मध्ये आवश्यक अँप शोधण्यासाठी जाऊ शकता."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -333,7 +359,9 @@ msgstr "पत्ता समजला नाही"
 
 msgctxt "error_page_content_text_unsupported_scheme"
 msgid "You might need to install other software to open this address."
-msgstr "हा पत्ता उघडण्यासाठी कदाचित आपल्याला इतर सॉफ्टवेअर स्थापित करणे आवश्यक आहे."
+msgstr ""
+"हा पत्ता उघडण्यासाठी कदाचित आपल्याला इतर सॉफ्टवेअर स्थापित करणे आवश्यक "
+"आहे."
 
 #. Label used in the contextmenu shown when long-pressing on a link
 msgctxt "contextmenu_link_share"
@@ -389,32 +417,66 @@ msgid "Browse faster than ever"
 msgstr "नेहमीपेक्षा जलद ब्राउझ करा"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "आपले ब्राऊझिंग अतिजलद बनवण्यासाठी टर्बो मोड वापरून मागोवा घेणाऱ्या जाहिराती आडवा. जर एखादे संकेतस्थळ मोडकळलेले दिसले तर फक्त मेनू मधून टर्बो मोड बंद करा."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"आपले ब्राऊझिंग अतिजलद बनवण्यासाठी टर्बो मोड वापरून मागोवा घेणाऱ्या "
+"जाहिराती आडवा. जर एखादे संकेतस्थळ मोडकळलेले दिसले तर फक्त मेनू मधून टर्बो"
+" मोड बंद करा."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "डेटा वाचवा = पैसे वाचवा"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "ट्रॅकिंग जाहिराती अडवून डेटा खर्च वाचवा. प्रतिमा अवरोध सक्षम करून आणखी बचत करा."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"ट्रॅकिंग जाहिराती अडवून डेटा खर्च वाचवा. प्रतिमा अवरोध सक्षम करून आणखी "
+"बचत करा."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "पूर्ण पृष्ठाचा स्क्रीनशॉट घ्या"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "पूर्ण पृष्ठाचा स्क्रीनशॉट घ्या. डेटा न वापरता ऑफलाईन पहा किंवा पुन्हा भेट देण्यासाठी टॅप करा."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"पूर्ण पृष्ठाचा स्क्रीनशॉट घ्या. डेटा न वापरता ऑफलाईन पहा किंवा पुन्हा भेट"
+" देण्यासाठी टॅप करा."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "पुढील स्तरीय गोपनीयता"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "मागमूसावीन ब्राउझ करा, आणि असंख्य साधारण वेब ट्रॅकर पूर्वनिर्धारीतरित्या आडवा. आपल्या गुप्त माहितीची सुरक्षा निश्चित करा."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"मागमूसावीन ब्राउझ करा, आणि असंख्य साधारण वेब ट्रॅकर पूर्वनिर्धारीतरित्या "
+"आडवा. आपल्या गुप्त माहितीची सुरक्षा निश्चित करा."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +489,12 @@ msgstr "आम्ही नवीन रूप धारण केलंय!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "विकसित उत्पादनासह, आम्ही नवीन आणि ताजे %1$s सादर करत आहे, नवीन नाव व चिन्हासह."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"विकसित उत्पादनासह, आम्ही नवीन आणि ताजे %1$s सादर करत आहे, नवीन नाव व "
+"चिन्हासह."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,8 +614,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "स्थान उपलब्ध नाही. आपले स्थान माहिती करण्याची परवानगी द्या."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "संचयन उपलब्ध नाही. आपल्या डिव्हाइसवर फोटो आणि फाईल साठवण्या करिता परवानगी द्या."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"संचयन उपलब्ध नाही. आपल्या डिव्हाइसवर फोटो आणि फाईल साठवण्या करिता परवानगी"
+" द्या."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -560,7 +630,11 @@ msgid ""
 "%1$s \n"
 "wants to access your location."
 msgstr ""
-"%1$s                                                                                                                                                                                                                                     आपल्या स्थानाबद्दल माहिती प्राप्त करू इच्छित आहे!                                                                                                                                                                                                                               \n"
+"%1$s"
+"                                                                                                                                                                                                                                     "
+"आपल्या स्थानाबद्दल माहिती प्राप्त करू इच्छित आहे!"
+"                                                                                                                                                                                                                               \n"
+""
 "\n"
 
 #. A checkbox option in the dialog which ask users to give geolocation
@@ -936,8 +1010,12 @@ msgid "Product Update Notice"
 msgstr "उत्पादन अद्यतन सूचना"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "FIrefox Lite सर्वांसाठी सुधारण्यासाठी, आम्ही गोपनीयता धोरणात बदल केले आहेत. अधिक जाणून घेण्यासाठी टॅप करा."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"FIrefox Lite सर्वांसाठी सुधारण्यासाठी, आम्ही गोपनीयता धोरणात बदल केले "
+"आहेत. अधिक जाणून घेण्यासाठी टॅप करा."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -949,7 +1027,9 @@ msgstr "%1$s आवडलं का?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "आमचे उत्पादन निवडल्याबद्दल धन्यवाद. आपला अभिप्राय आमच्यासाठी महत्त्वाचा आहे."
+msgstr ""
+"आमचे उत्पादन निवडल्याबद्दल धन्यवाद. आपला अभिप्राय आमच्यासाठी महत्त्वाचा "
+"आहे."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -1000,15 +1080,21 @@ msgstr "अरे %3$s कडून हा जलद आणि हलका ब�
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s %2$s आणि इतर योगदानकर्त्यांनी बनवलेले मोफत आणि खुल्या स्रोताचे सॉफ्टवेअर आहे."
+msgstr ""
+"%1$s %2$s आणि इतर योगदानकर्त्यांनी बनवलेले मोफत आणि खुल्या स्रोताचे "
+"सॉफ्टवेअर आहे."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s आपल्याला <a href=\"%2$s\">%3$s</a> आणि इतर खुल्या स्त्रोत परवान्यांच्या नियमांतर्गत उपलब्ध करून दिले गेले आहे."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s आपल्याला <a href=\"%2$s\">%3$s</a> आणि इतर खुल्या स्त्रोत "
+"परवान्यांच्या नियमांतर्गत उपलब्ध करून दिले गेले आहे."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1017,16 +1103,24 @@ msgstr "%1$s आपल्याला <a href=\"%2$s\">%3$s</a> आणि इत
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
-msgstr "%3$s, %4$s किंवा %1$s यांच्या नाव व चिन्हांसह Mozilla Foundation किंवा इतर पार्टीच्या व्यापारचिन्हाचे हक्क किंवा परवाने आपणास दिलेले नाहीत. अधिक माहिती <a href=\"%2$s\">इथे</a> मिळेल."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
+msgstr ""
+"%3$s, %4$s किंवा %1$s यांच्या नाव व चिन्हांसह Mozilla Foundation किंवा "
+"इतर पार्टीच्या व्यापारचिन्हाचे हक्क किंवा परवाने आपणास दिलेले नाहीत. अधिक"
+" माहिती <a href=\"%2$s\">इथे</a> मिळेल."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s साठी अधिक स्रोत कोड इतर अनेक मुक्त आणि खुल्या स्त्रोताच्या <a href=\"%2$s\">परवान्यांतर्गत</a> उपलब्ध आहे."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s साठी अधिक स्रोत कोड इतर अनेक मुक्त आणि खुल्या स्त्रोताच्या <a "
+"href=\"%2$s\">परवान्यांतर्गत</a> उपलब्ध आहे."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1034,10 +1128,14 @@ msgstr "%1$s साठी अधिक स्रोत कोड इतर अ�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s Disconnect, Inc. यांनी पुरवलेले अवरोध तक्ते स्वतंत्र व विभक्त कार्य म्हणून पण वापरते जे <a href=\"%2$s\">GNU General Public License v3</a> अंतर्गत उपलब्ध आहे आणि <a href=\"%3$s\">इथून</a> "
-"मिळवता येते."
+"%1$s Disconnect, Inc. यांनी पुरवलेले अवरोध तक्ते स्वतंत्र व विभक्त कार्य "
+"म्हणून पण वापरते जे <a href=\"%2$s\">GNU General Public License v3</a> "
+"अंतर्गत उपलब्ध आहे आणि <a href=\"%3$s\">इथून</a> मिळवता येते."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1209,26 +1307,36 @@ msgstr "येथे आपले स्क्रीनशॉट्स पहा
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "आपला अनुभव सुधारण्यासाठी, आम्ही आपल्या स्क्रीनशॉटच्या श्रेणीची माहिती गोळा करतो."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"आपला अनुभव सुधारण्यासाठी, आम्ही आपल्या स्क्रीनशॉटच्या श्रेणीची माहिती "
+"गोळा करतो."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "7-दिवस विनामुल्य VPN सेवा आपल्यासाठी तयार आहे. अधिक खाजगीरीत्या आणि सुरक्षिततेने ब्राउझ करण्यासाठी आता स्थापित करा."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"7-दिवस विनामुल्य VPN सेवा आपल्यासाठी तयार आहे. अधिक खाजगीरीत्या आणि "
+"सुरक्षिततेने ब्राउझ करण्यासाठी आता स्थापित करा."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"आपल्याला जवळचे मोफत इंटरनेट शोधून देण्यासाठी आम्ही “मोफत वायफाय-शोधक” सामावण्याच्या विचारात आहे.\n"
+"आपल्याला जवळचे मोफत इंटरनेट शोधून देण्यासाठी आम्ही “मोफत वायफाय-शोधक” "
+"सामावण्याच्या विचारात आहे.\n"
 "इच्छुक आहात?"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
@@ -1236,11 +1344,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"आपल्याला ब्राऊझिंग करताना अधिक स्वातंत्र्य व गोपनीयता देण्यासाठी “VPN सेवा” समाविष्ट करण्याच्या विचारात आहे.\n"
+"आपल्याला ब्राऊझिंग करताना अधिक स्वातंत्र्य व गोपनीयता देण्यासाठी “VPN "
+"सेवा” समाविष्ट करण्याच्या विचारात आहे.\n"
 "\n"
 "इच्छुक आहात?"
 
@@ -1262,3 +1372,4 @@ msgstr "YES, PLEASE"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "NOPE"
+

--- a/locales/pa-IN/app.po
+++ b/locales/pa-IN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-20 05:03+0000\n"
 "Last-Translator: Aman Alam <amanpreet.alam@gmail.com>\n"
 "Language: pa_Guru_IN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ਪਰਦੇਦਾਰੀ ਸੂਚਨਾ"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -466,16 +472,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/pa-IN/app.po
+++ b/locales/pa-IN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-20 05:03+0000\n"
 "Last-Translator: Aman Alam <amanpreet.alam@gmail.com>\n"
+"Language: pa_Guru_IN\n"
 "Language-Team: pa_Guru_IN <LL@li.org>\n"
-"Language: pa_IN\n"
+"Plural-Forms: nplurals=2; plural=(((n >= 0 && n <= 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "ਫਾਇਰਫਾਕਸ ਲਾਈਟ ਵਿੱਚ ਖੋਜੋ"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%2$s ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ %1$s ਇੱਕ ਹਲਕਾ ਅਤੇ ਤੇਜ਼ ਬਰਾਊਜ਼ਰ ਹੈ। ਸਾਡਾ ਟੀਚਾ ਇੱਕ ਸਿਹਤਮੰਦ ਅਤੇ ਖੁੱਲ੍ਹੇ-ਡੁੱਲ੍ਹੇ ਇੰਟਰਨੈੱਟ ਨੂੰ ਵਧਾਉਣਾ ਫੁਲਾਉਣਾ ਹੈ।"
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%2$s ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ %1$s ਇੱਕ ਹਲਕਾ ਅਤੇ ਤੇਜ਼ ਬਰਾਊਜ਼ਰ ਹੈ। ਸਾਡਾ ਟੀਚਾ ਇੱਕ "
+"ਸਿਹਤਮੰਦ ਅਤੇ ਖੁੱਲ੍ਹੇ-ਡੁੱਲ੍ਹੇ ਇੰਟਰਨੈੱਟ ਨੂੰ ਵਧਾਉਣਾ ਫੁਲਾਉਣਾ ਹੈ।"
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "ਤੁਹਾਡੇ ਹੱਕ / ਲਸੰਸ"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ਪਰਦੇਦਾਰੀ ਸੂਚਨਾ"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "ਸਿਸਟਮ ਡਿਫੌਲਟ"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "ਡਿਫੌਲਟ ਖੋਜ ਇੰਜਣ"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "ਵਰਤੋਂ ਸਬੰਧੀ ਡੇਟਾ ਭੇਜੋ"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s ਭਰਪੂਰ ਕੋਸ਼ਿਸ਼ ਕਰਦਾ ਹੈ ਕਿ ਸਿਰਫ ਉਹੀ ਕੁੱਝ ਇਕੱਠਾ ਕੀਤਾ ਜਾਵੇ ਜੋ ਕਿ %1$s ਨੂੰ ਹਰੇਕ ਲਈ ਮੁਹੱਈਆ ਕਰਾਉਣ ਅਤੇ ਹੋਰ ਸੁਧਾਰਨ ਲਈ ਲੋੜੀਂਦਾ ਹੋਵੇ।"
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s ਭਰਪੂਰ ਕੋਸ਼ਿਸ਼ ਕਰਦਾ ਹੈ ਕਿ ਸਿਰਫ ਉਹੀ ਕੁੱਝ ਇਕੱਠਾ ਕੀਤਾ ਜਾਵੇ ਜੋ ਕਿ %1$s ਨੂੰ "
+"ਹਰੇਕ ਲਈ ਮੁਹੱਈਆ ਕਰਾਉਣ ਅਤੇ ਹੋਰ ਸੁਧਾਰਨ ਲਈ ਲੋੜੀਂਦਾ ਹੋਵੇ।"
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "ਅਜਿਹੀ ਐਪ ਲੱਭੋ ਜੋ ਲਿੰਕ ਨੂੰ ਖੋ
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "ਤੁਹਾਡੇ ਯੰਤਰ ਉੱਪਰਲੀ ਕੋਈ ਵੀ ਐਪ ਇਸ ਲਿੰਕ ਨੂੰ ਖੋਲ੍ਹਣ ਦੇ ਕਾਬਲ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ %2$s ਦੇ ਲਈ ਕਿਸੇ ਕਾਬਲ ਐਪ ਨੂੰ ਲੱਭਣ ਲਈ %1$s ਛੱਡ ਸਕਦੇ ਹੋ।"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"ਤੁਹਾਡੇ ਯੰਤਰ ਉੱਪਰਲੀ ਕੋਈ ਵੀ ਐਪ ਇਸ ਲਿੰਕ ਨੂੰ ਖੋਲ੍ਹਣ ਦੇ ਕਾਬਲ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ "
+"%2$s ਦੇ ਲਈ ਕਿਸੇ ਕਾਬਲ ਐਪ ਨੂੰ ਲੱਭਣ ਲਈ %1$s ਛੱਡ ਸਕਦੇ ਹੋ।"
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -382,40 +408,75 @@ msgstr "%1$s ਨੂੰ ਚੁਣਨ ਲਈ ਧੰਨਵਾਦ ਜੀ"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਸਥਾ ਦੇ ਤੌਰ ਤੇ ਮੁਫਤ ਅਤੇ ਖੁੱਲ੍ਹੇ-ਡੁੱਲ੍ਹੇ ਵੈੱਬ ਲਈ ਵਚਨਵੱਧ %1$s ਦੇ ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ ਬਰਾਊਜ਼ਰ।"
+msgstr ""
+"ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਸਥਾ ਦੇ ਤੌਰ ਤੇ ਮੁਫਤ ਅਤੇ ਖੁੱਲ੍ਹੇ-ਡੁੱਲ੍ਹੇ ਵੈੱਬ ਲਈ ਵਚਨਵੱਧ "
+"%1$s ਦੇ ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ ਬਰਾਊਜ਼ਰ।"
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "ਸਭ ਤੋਂ ਤੇਜ ਬਰਾਊਜ਼ ਕਰੋ"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
 msgstr ""
-"ਤੁਹਾਡੀ ਪੈੜ੍ਹ ਨੱਪਣ ਵਾਲੀਆਂ ਮਸ਼ਹੂਰੀਆਂ ਤੇ ਰੋਕ ਲਾਉਣ ਲਈ ਟਰਬੋ ਮੋਡ ਵਰਤੋ ਤਾਂ ਕਿ ਤੁਸੀਂ ਬਿਜਲੀ ਦੀ ਤੇਜੀ ਨਾਲ ਬਰਾਊਜ਼ ਕਰ ਸਕੋ। ਜੇ ਸਾਈਟਾਂ ਕਿਤੇ ਵਿੱਚ ਖੜੋਤ ਆਉਂਦੀ ਦਿਸੇ ਤਾਂ ਮੇਨੂ ਵਿੱਚੋਂ ਬੱਸ ਟਰਬੋ ਮੋਡ ਬਟਨ ਛੂਹ ਕੇ ਬੰਦ ਕਰ ਦਿਉ।"
+"ਤੁਹਾਡੀ ਪੈੜ੍ਹ ਨੱਪਣ ਵਾਲੀਆਂ ਮਸ਼ਹੂਰੀਆਂ ਤੇ ਰੋਕ ਲਾਉਣ ਲਈ ਟਰਬੋ ਮੋਡ ਵਰਤੋ ਤਾਂ ਕਿ "
+"ਤੁਸੀਂ ਬਿਜਲੀ ਦੀ ਤੇਜੀ ਨਾਲ ਬਰਾਊਜ਼ ਕਰ ਸਕੋ। ਜੇ ਸਾਈਟਾਂ ਕਿਤੇ ਵਿੱਚ ਖੜੋਤ ਆਉਂਦੀ "
+"ਦਿਸੇ ਤਾਂ ਮੇਨੂ ਵਿੱਚੋਂ ਬੱਸ ਟਰਬੋ ਮੋਡ ਬਟਨ ਛੂਹ ਕੇ ਬੰਦ ਕਰ ਦਿਉ।"
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "ਡੇਟਾ ਦੀ ਬੱਚਤ = ਪੈਸੇ ਦੀ ਬੱਚਤ"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "ਤੁਹਾਡੀ ਪੈੜ੍ਹ ਨੱਪਣ ਵਾਲੀਆਂ ਮਸ਼ਹੂਰੀਆਂ ਨਾਲ ਡਾਟੇ ਦੀ ਬੱਚਤ ਹੁੰਦੀ ਹੈ। ਜੇ ਤੁਸੀਂ ਤਸਵੀਰਾਂ ਤੇ ਪਾਬੰਦੀ ਲਾ ਦਿਉ ਤਾਂ ਬੱਚਤ ਹੋਰ ਵੀ ਜਿਆਦਾ ਹੁੰਦੀ ਹੈ।"
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"ਤੁਹਾਡੀ ਪੈੜ੍ਹ ਨੱਪਣ ਵਾਲੀਆਂ ਮਸ਼ਹੂਰੀਆਂ ਨਾਲ ਡਾਟੇ ਦੀ ਬੱਚਤ ਹੁੰਦੀ ਹੈ। ਜੇ ਤੁਸੀਂ "
+"ਤਸਵੀਰਾਂ ਤੇ ਪਾਬੰਦੀ ਲਾ ਦਿਉ ਤਾਂ ਬੱਚਤ ਹੋਰ ਵੀ ਜਿਆਦਾ ਹੁੰਦੀ ਹੈ।"
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "ਪੂਰੇ ਸਫ਼ੇ ਦਾ ਸਕਰੀਨ-ਸ਼ਾਟ ਲਵੋ"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "ਪੂਰੇ ਸਫ਼ੇ ਨੂੰ ਸਕਰੋਲ ਕਰਕੇ ਸਕਰੀਨਸ਼ਾਟ ਲਵੋ। ਇਸ ਨੂੰ ਔਫਲਾਇਨ ਬਗੈਰ ਡੇਟਾ ਵਰਤੇ ਪੜ੍ਹੋ ਜਾਂ ਮੁੜ ਕੇ ਉਸ ਵਰਕੇ ਤੇ ਜਾਣ ਲਈ ਇਸ ਨੂੰ ਛੂਹੋ।"
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"ਪੂਰੇ ਸਫ਼ੇ ਨੂੰ ਸਕਰੋਲ ਕਰਕੇ ਸਕਰੀਨਸ਼ਾਟ ਲਵੋ। ਇਸ ਨੂੰ ਔਫਲਾਇਨ ਬਗੈਰ ਡੇਟਾ ਵਰਤੇ "
+"ਪੜ੍ਹੋ ਜਾਂ ਮੁੜ ਕੇ ਉਸ ਵਰਕੇ ਤੇ ਜਾਣ ਲਈ ਇਸ ਨੂੰ ਛੂਹੋ।"
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "ਅਗਲੇ-ਪੱਧਰ ਦੀ ਪਰਦੇਦਾਰੀ"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "ਬਿਨਾਂ ਪੈੜਾਂ ਛੱਡੇ ਬਰਾਊਜ਼ ਕਰੋ, ਅਤੇ ਡਿਫਾਲਟ ਰੂਪ ਵਿੱਚ ਆਮ ਵੈਬ ਟਰੈਕਕਰਜ਼ ਦੀ ਵਿਸ਼ਾਲ ਲੜੀ ਉਤੇ ਪਾਬੰਦੀ ਕਰੋ। ਆਪਣੇ ਗੁਪਤ ਡਾਟਾ ਦੀ ਸੁਰੱਖਿਆ ਨੂੰ ਯਕੀਨੀ ਬਣਾਓ।"
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"ਬਿਨਾਂ ਪੈੜਾਂ ਛੱਡੇ ਬਰਾਊਜ਼ ਕਰੋ, ਅਤੇ ਡਿਫਾਲਟ ਰੂਪ ਵਿੱਚ ਆਮ ਵੈਬ ਟਰੈਕਕਰਜ਼ ਦੀ "
+"ਵਿਸ਼ਾਲ ਲੜੀ ਉਤੇ ਪਾਬੰਦੀ ਕਰੋ। ਆਪਣੇ ਗੁਪਤ ਡਾਟਾ ਦੀ ਸੁਰੱਖਿਆ ਨੂੰ ਯਕੀਨੀ ਬਣਾਓ।"
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -428,8 +489,12 @@ msgstr "ਸਾਡੇ ਕੋਲ ਨਵੀਂ ਦਿੱਖ ਹੈ!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "ਵਿਕਾਸ ਹੋਏ ਉਤਪਾਦ ਦੇ ਨਾਲ, ਅਸੀਂ ਤੁਹਾਨੂੰ ਨਵੇਂ ਨਾਂ ਅਤੇ ਨਵੇਂ ਲੋਗੋ ਦੇ ਨਾਲ ਇੱਕ ਤਾਜ਼ਾ ਰਿਫ੍ਰੈਸ਼ਡ %1$s ਲਿਆਉਂਦੇ ਹਾਂ।"
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"ਵਿਕਾਸ ਹੋਏ ਉਤਪਾਦ ਦੇ ਨਾਲ, ਅਸੀਂ ਤੁਹਾਨੂੰ ਨਵੇਂ ਨਾਂ ਅਤੇ ਨਵੇਂ ਲੋਗੋ ਦੇ ਨਾਲ ਇੱਕ "
+"ਤਾਜ਼ਾ ਰਿਫ੍ਰੈਸ਼ਡ %1$s ਲਿਆਉਂਦੇ ਹਾਂ।"
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -549,8 +614,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "ਸਥਾਨ ਉਪਲੱਬਧ ਨਹੀਂ ਹੈ। ਤੁਹਾਡੇ ਸਥਾਨ ਤੱਕ ਪਹੁੰਚਣ ਦੀ ਅਾਗਿਆ ਦਿਓ।"
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "ਸਟੋਰੇਜ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਆਪਣੀ ਡਿਵਾਈਸ ਤੇ ਫੋਟੋਆਂ ਅਤੇ ਫਾਈਲਾਂ ਨੂੰ ਸਟੋਰ ਕਰਨ ਦੀ ਅਾਗਿਆ ਦਿਓ।"
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"ਸਟੋਰੇਜ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਆਪਣੀ ਡਿਵਾਈਸ ਤੇ ਫੋਟੋਆਂ ਅਤੇ ਫਾਈਲਾਂ ਨੂੰ ਸਟੋਰ ਕਰਨ ਦੀ "
+"ਅਾਗਿਆ ਦਿਓ।"
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -933,8 +1002,12 @@ msgid "Product Update Notice"
 msgstr "ਉਤਪਾਦ ਅਪਡੇਟ ਨੋਟਿਸ"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "ਤੁਹਾਡੇ ਲਈ ਤੇ ਹਰੇਕ ਲਈ ਫਾਇਰਫਾਕਸ ਰੌਕੇਟ ਨੂੰ ਵਧੀਆ ਬਣਾਉਣ ਲਈ, ਅਸੀਂ ਆਪਣੀ ਪਰਦੇਦਾਰੀ ਨੀਤੀ ਵਿੱਚ ਕੁਝ ਬਦਲਾਅ ਕੀਤੇ ਹਨ। ਹੋਰ ਜਾਨਣ ਲਈ ਛੂਹੋ।"
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"ਤੁਹਾਡੇ ਲਈ ਤੇ ਹਰੇਕ ਲਈ ਫਾਇਰਫਾਕਸ ਰੌਕੇਟ ਨੂੰ ਵਧੀਆ ਬਣਾਉਣ ਲਈ, ਅਸੀਂ ਆਪਣੀ ਪਰਦੇਦਾਰੀ"
+" ਨੀਤੀ ਵਿੱਚ ਕੁਝ ਬਦਲਾਅ ਕੀਤੇ ਹਨ। ਹੋਰ ਜਾਨਣ ਲਈ ਛੂਹੋ।"
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -994,15 +1067,21 @@ msgstr "ਜ਼ਰਾ, %3$s ਦਾ ਇਹ ਤੇਜ਼ ਅਤੇ ਹਲਕਾ ਫ
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%2$s ਅਤੇ ਹੋਰ ਯੋਗਦਾਨੀਆਂ ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ %1$s ਇੱਕ ਮੁਫ਼ਤ ਅਤੇ ਓਪਨ ਸੋਰਸ ਸਾਫਟਵੇਅਰ ਹੈ।"
+msgstr ""
+"%2$s ਅਤੇ ਹੋਰ ਯੋਗਦਾਨੀਆਂ ਵੱਲੋਂ ਬਣਾਇਆ ਗਿਆ %1$s ਇੱਕ ਮੁਫ਼ਤ ਅਤੇ ਓਪਨ ਸੋਰਸ "
+"ਸਾਫਟਵੇਅਰ ਹੈ।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s ਤੁਹਾਨੂੰ <a href=\"%2$s\">%3$s</a> ਅਤੇ ਹੋਰ ਖੁੱਲ੍ਹੇ ਵਸੀਲਿਆਂ (ਓਪਨ ਸੋਰਸ) ਦੇ ਲਸੰਸਾਂ ਦੀਆਂ ਸ਼ਰਤਾਂ ਹੇਠ ਮੁਹੱਈਆ ਕਰਵਾਇਆ ਗਿਆ ਹੈ।"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s ਤੁਹਾਨੂੰ <a href=\"%2$s\">%3$s</a> ਅਤੇ ਹੋਰ ਖੁੱਲ੍ਹੇ ਵਸੀਲਿਆਂ (ਓਪਨ ਸੋਰਸ)"
+" ਦੇ ਲਸੰਸਾਂ ਦੀਆਂ ਸ਼ਰਤਾਂ ਹੇਠ ਮੁਹੱਈਆ ਕਰਵਾਇਆ ਗਿਆ ਹੈ।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1011,18 +1090,24 @@ msgstr "%1$s ਤੁਹਾਨੂੰ <a href=\"%2$s\">%3$s</a> ਅਤੇ ਹੋਰ
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"ਤੁਹਾਨੂੰ ਮੋਜ਼ੀਲਾ ਫਾਊਂਡੇਸ਼ਨ ਜਾਂ ਕਿਤੇ ਵੀ ਹੋਰ ਧਿਰ ਦੇ ਟਰੇਡਮਾਰਕ ਲਈ ਹੱਕ ਜਾਂ ਲਸੰਸ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਦਿੱਤੀ ਗਈ ਹੈ, ਜਿਸ ਵਿੱਚ %3$s, %4$s ਜਾਂ %1$s ਨਾਂ ਜਾਂ ਲੋਗੋ ਸ਼ਾਮਲ ਹਨ। ਹੋਰ ਜਾਣਕਾਰੀ <a href=\"%2$s\">ਇੱਥੇ</a> ਲੱਭੀ ਜਾ "
-"ਸਕਦੀ ਹੈ।"
+"ਤੁਹਾਨੂੰ ਮੋਜ਼ੀਲਾ ਫਾਊਂਡੇਸ਼ਨ ਜਾਂ ਕਿਤੇ ਵੀ ਹੋਰ ਧਿਰ ਦੇ ਟਰੇਡਮਾਰਕ ਲਈ ਹੱਕ ਜਾਂ ਲਸੰਸ "
+"ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਦਿੱਤੀ ਗਈ ਹੈ, ਜਿਸ ਵਿੱਚ %3$s, %4$s ਜਾਂ %1$s ਨਾਂ ਜਾਂ ਲੋਗੋ ਸ਼ਾਮਲ"
+" ਹਨ। ਹੋਰ ਜਾਣਕਾਰੀ <a href=\"%2$s\">ਇੱਥੇ</a> ਲੱਭੀ ਜਾ ਸਕਦੀ ਹੈ।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s ਲਈ ਹੋਰ ਸੋਰਸ ਕੋਡ ਹੋਰ ਕਈ ਮੁਫਤ ਅਤੇ ਖੁੱਲ੍ਹੇ ਵਸੀਲਿਆਂ (ਓਪਨ ਸੋਰਸ) ਦੇ <a href=\"%2$s\">ਲਸੰਸਾਂ</a> ਹੇਠ ਮਿਲਦਾ ਹੈ।"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s ਲਈ ਹੋਰ ਸੋਰਸ ਕੋਡ ਹੋਰ ਕਈ ਮੁਫਤ ਅਤੇ ਖੁੱਲ੍ਹੇ ਵਸੀਲਿਆਂ (ਓਪਨ ਸੋਰਸ) ਦੇ <a "
+"href=\"%2$s\">ਲਸੰਸਾਂ</a> ਹੇਠ ਮਿਲਦਾ ਹੈ।"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1030,8 +1115,14 @@ msgstr "%1$s ਲਈ ਹੋਰ ਸੋਰਸ ਕੋਡ ਹੋਰ ਕਈ ਮੁਫ�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s Disconnect, Inc. ਵਲੋਂ ਪਾਬੰਦੀਸੁਦਾ-ਸੂਚੀਆਂ ਦੀ ਵਰਤੋਂ ਵੱਖਰੇ ਅਤੇ ਆਜ਼ਾਦਾਨਾ ਤੌਰ 'ਤੇ <a href=\"%2$s\">GNU ਜਰਨਲ ਪਬਲਿਕ ਲਸੰਸ v3</a> ਦੇ ਤਹਿਤ ਕਰਦਾ ਹੈ ਅਤੇ ਇਹ <a href=\"%3$s\">ਇੱਥ ਮੌਜੂਦ ਹੈ</a>।"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s Disconnect, Inc. ਵਲੋਂ ਪਾਬੰਦੀਸੁਦਾ-ਸੂਚੀਆਂ ਦੀ ਵਰਤੋਂ ਵੱਖਰੇ ਅਤੇ ਆਜ਼ਾਦਾਨਾ "
+"ਤੌਰ 'ਤੇ <a href=\"%2$s\">GNU ਜਰਨਲ ਪਬਲਿਕ ਲਸੰਸ v3</a> ਦੇ ਤਹਿਤ ਕਰਦਾ ਹੈ ਅਤੇ "
+"ਇਹ <a href=\"%3$s\">ਇੱਥ ਮੌਜੂਦ ਹੈ</a>।"
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1201,26 +1292,36 @@ msgstr "ਇੱਥੇ ਆਪਣੇ ਸਕ੍ਰੀਨਸ਼ੌਟ ਵੇਖੋ!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "ਤੁਹਾਡੇ ਉਤਪਾਦ ਅਨੁਭਵ ਨੂੰ ਬਿਹਤਰ ਬਣਾਉਣ ਲਈ, ਅਸੀਂ ਤੁਹਾਡੇ ਸਕ੍ਰੀਨਸ਼ਾਟ ਦੇ ਵਰਗਾਂ ਦੇ ਬਾਰੇ ਜਾਣਕਾਰੀ ਇਕੱਠੀ ਕਰਦੇ ਹਾਂ।"
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"ਤੁਹਾਡੇ ਉਤਪਾਦ ਅਨੁਭਵ ਨੂੰ ਬਿਹਤਰ ਬਣਾਉਣ ਲਈ, ਅਸੀਂ ਤੁਹਾਡੇ ਸਕ੍ਰੀਨਸ਼ਾਟ ਦੇ ਵਰਗਾਂ ਦੇ"
+" ਬਾਰੇ ਜਾਣਕਾਰੀ ਇਕੱਠੀ ਕਰਦੇ ਹਾਂ।"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "7-ਦਿਨ ਦੀ ਮੁਫਤ VPN ਸੇਵਾ ਤੁਹਾਡੇ ਲਈ ਤਿਆਰ ਹੈ। ਪ੍ਰਾਈਵੇਟ ਅਤੇ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ ਬਰਾਊਜ਼ ਕਰਨ ਲਈ ਹੁਣ ਇੰਸਟਾਲ ਕਰੋ।"
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"7-ਦਿਨ ਦੀ ਮੁਫਤ VPN ਸੇਵਾ ਤੁਹਾਡੇ ਲਈ ਤਿਆਰ ਹੈ। ਪ੍ਰਾਈਵੇਟ ਅਤੇ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ "
+"ਬਰਾਊਜ਼ ਕਰਨ ਲਈ ਹੁਣ ਇੰਸਟਾਲ ਕਰੋ।"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"ਅਸੀਂ ਨੇੜਲੇ ਮੁਕਾਬਲਤਨ ਮੁਫ਼ਤ ਇੰਟਰਨੈਟ ਕਨੈਕਸ਼ਨ ਲੱਭਣ ਵਿੱਚ ਤੁਹਾਡੀ ਮਦਦ ਲਈ “Free Wifi-Finder” ਨੂੰ ਜੋੜਨ ਦੀ ਯੋਜਨਾ ਬਣਾ ਰਹੇ ਹਾਂ।\n"
+"ਅਸੀਂ ਨੇੜਲੇ ਮੁਕਾਬਲਤਨ ਮੁਫ਼ਤ ਇੰਟਰਨੈਟ ਕਨੈਕਸ਼ਨ ਲੱਭਣ ਵਿੱਚ ਤੁਹਾਡੀ ਮਦਦ ਲਈ “Free "
+"Wifi-Finder” ਨੂੰ ਜੋੜਨ ਦੀ ਯੋਜਨਾ ਬਣਾ ਰਹੇ ਹਾਂ।\n"
 "\n"
 " ਦਿਲਚਸਪੀ ਹੈ?"
 
@@ -1229,11 +1330,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"ਬਰਾਊਜ਼ ਕਰਨ ਵੇਲੇ ਅਸੀਂ ਤੁਹਾਨੂੰ ਵਧੇਰੇ ਆਜ਼ਾਦੀ ਅਤੇ ਹੋਰ ਪਰਦੇਦਾਰੀ ਪ੍ਰਾਪਤ ਕਰਨ ਲਈ “VPN ਸੇਵਾ” ਨੂੰ ਜੋੜਨ ਦੀ ਯੋਜਨਾ ਬਣਾਉਂਦੇ ਹਾਂ।\n"
+"ਬਰਾਊਜ਼ ਕਰਨ ਵੇਲੇ ਅਸੀਂ ਤੁਹਾਨੂੰ ਵਧੇਰੇ ਆਜ਼ਾਦੀ ਅਤੇ ਹੋਰ ਪਰਦੇਦਾਰੀ ਪ੍ਰਾਪਤ ਕਰਨ ਲਈ "
+"“VPN ਸੇਵਾ” ਨੂੰ ਜੋੜਨ ਦੀ ਯੋਜਨਾ ਬਣਾਉਂਦੇ ਹਾਂ।\n"
 "\n"
 " ਦਿਲਚਸਪੀ ਹੈ?"
 
@@ -1255,3 +1358,4 @@ msgstr "ਜੀ, ਜਰੂਰ"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "ਨਹੀਂ"
+

--- a/locales/ru/app.po
+++ b/locales/ru/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-20 10:16+0000\n"
 "Last-Translator: Alexander Slovesnik <unghost@mozilla-russia.org>\n"
 "Language: ru\n"
@@ -22,7 +22,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -143,11 +143,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Уведомление о конфиденциальности"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -473,16 +479,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/ru/app.po
+++ b/locales/ru/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-20 10:16+0000\n"
 "Last-Translator: Alexander Slovesnik <unghost@mozilla-russia.org>\n"
-"Language-Team: ru <LL@li.org>\n"
 "Language: ru\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 10) >= 2 && (n %"
+" 10) <= 4))) && (!(((n % 100) >= 12 && (n % 100) <= 14)))) ? 1 : (((((0 "
+"== 0)) && (((n % 10) == 0))) || (((0 == 0)) && (((n % 10) >= 5 && (n % "
+"10) <= 9)))) || (((0 == 0)) && (((n % 100) >= 11 && (n % 100) <= 14)))) ?"
+" 2 : ((((0 == 0)) && (((n % 10) == 1))) && (!(((n % 100) == 11)))) ? 0 : "
+"3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +120,12 @@ msgstr "Искать в Firefox Lite"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s — быстрый и легкий браузер, созданный %2$s. Нашей миссией является обеспечение здоровья и открытости Интернета."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s — быстрый и легкий браузер, созданный %2$s. Нашей миссией является "
+"обеспечение здоровья и открытости Интернета."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +142,16 @@ msgstr "Ваши права / Лицензии"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Уведомление о конфиденциальности"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +172,11 @@ msgstr "Язык устройства"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Поисковая система по умолчанию"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +219,12 @@ msgstr "Отправлять данные об использовании"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s стремится собирать только ту информацию, которая необходима для работы %1$s и его улучшения в будущем."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s стремится собирать только ту информацию, которая необходима для "
+"работы %1$s и его улучшения в будущем."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +334,12 @@ msgstr "Найдите приложение, которое может откр�
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ни одно из приложений на вашем устройстве не может открыть эту ссылку. Вы можете выйти из %1$s для поиска подходящего приложения в %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ни одно из приложений на вашем устройстве не может открыть эту ссылку. Вы"
+" можете выйти из %1$s для поиска подходящего приложения в %2$s."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -333,7 +364,9 @@ msgstr "Неизвестный тип адреса"
 
 msgctxt "error_page_content_text_unsupported_scheme"
 msgid "You might need to install other software to open this address."
-msgstr "Для открытия этого адреса вам может понадобиться установить другое программное обеспечение."
+msgstr ""
+"Для открытия этого адреса вам может понадобиться установить другое "
+"программное обеспечение."
 
 #. Label used in the contextmenu shown when long-pressing on a link
 msgctxt "contextmenu_link_share"
@@ -382,41 +415,75 @@ msgstr "Спасибо, что выбрали %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "Браузер, созданный %1$s, некоммерческой организацией, преданной свободному и открытому Интернету."
+msgstr ""
+"Браузер, созданный %1$s, некоммерческой организацией, преданной "
+"свободному и открытому Интернету."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "Сёрфите быстрее, чем когда-либо"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
 msgstr ""
-"Используйте режим Турбо, чтобы блокировать трекеры рекламы, так вы сможете просматривать сайты на молниеносной скорости. Если сайты кажутся сломанными, просто нажмите переключатель режима Турбо в "
-"меню."
+"Используйте режим Турбо, чтобы блокировать трекеры рекламы, так вы "
+"сможете просматривать сайты на молниеносной скорости. Если сайты кажутся "
+"сломанными, просто нажмите переключатель режима Турбо в меню."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "Экономия трафика = Экономия денег"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "Экономьте на расходах на Интернет, блокируя трекеры рекламы. Сэкономьте ещё больше, включив блокировку изображений."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"Экономьте на расходах на Интернет, блокируя трекеры рекламы. Сэкономьте "
+"ещё больше, включив блокировку изображений."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "Скриншот всей страницы"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "Сделайте скриншот всей страницы. Читайте её оффлайн без использования Интернета или нажмите на него, чтобы вернуться на веб-страницу."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"Сделайте скриншот всей страницы. Читайте её оффлайн без использования "
+"Интернета или нажмите на него, чтобы вернуться на веб-страницу."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "Следующий уровень приватности"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "Просмотр страниц без слежки и блокировка распространенных веб-трекеров по умолчанию. Обеспечьте безопасность ваших конфиденциальных данных."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"Просмотр страниц без слежки и блокировка распространенных веб-трекеров по"
+" умолчанию. Обеспечьте безопасность ваших конфиденциальных данных."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -429,8 +496,12 @@ msgstr "У нас новый вид!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "Благодаря развитию продукта, мы предлагаем вам обновленный %1$s с новым именем и логотипом."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"Благодаря развитию продукта, мы предлагаем вам обновленный %1$s с новым "
+"именем и логотипом."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -547,11 +618,17 @@ msgstr "не сейчас"
 
 msgctxt "permission_toast_location"
 msgid "Location not available. Give permission to access your location."
-msgstr "Местоположение недоступно. Дайте разрешение на доступ к вашему местоположению."
+msgstr ""
+"Местоположение недоступно. Дайте разрешение на доступ к вашему "
+"местоположению."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "Хранилище недоступно. Дайте разрешение на хранение фотографий и файлов на вашем устройстве."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"Хранилище недоступно. Дайте разрешение на хранение фотографий и файлов на"
+" вашем устройстве."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -938,8 +1015,13 @@ msgid "Product Update Notice"
 msgstr "Уведомление об обновлении продукта"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Чтобы сделать Firefox Lite лучше для вас и для всех, мы внесли некоторые изменения в нашу политику конфиденциальности. Нажмите, чтобы узнать больше."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Чтобы сделать Firefox Lite лучше для вас и для всех, мы внесли некоторые "
+"изменения в нашу политику конфиденциальности. Нажмите, чтобы узнать "
+"больше."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -1002,15 +1084,21 @@ msgstr "Привет, попробуй этот быстрый и лёгкий �
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s является бесплатной программой с открытым исходным кодом, созданной %2$s и другими участниками."
+msgstr ""
+"%1$s является бесплатной программой с открытым исходным кодом, созданной "
+"%2$s и другими участниками."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s предоставляется вам на условиях <a href=\"%2$s\">%3$s</a> и других лицензий для открытого исходного кода."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s предоставляется вам на условиях <a href=\"%2$s\">%3$s</a> и других "
+"лицензий для открытого исходного кода."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1019,18 +1107,25 @@ msgstr "%1$s предоставляется вам на условиях <a href
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"Вы не получаете никаких прав или лицензий на товарные знаки Mozilla Foundation или любой другой стороны, включая имена или логотипы %3$s, %4$s или %1$s. Дополнительную информацию можно найти <a "
+"Вы не получаете никаких прав или лицензий на товарные знаки Mozilla "
+"Foundation или любой другой стороны, включая имена или логотипы %3$s, "
+"%4$s или %1$s. Дополнительную информацию можно найти <a "
 "href=\"%2$s\">здесь</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Дополнительный исходный код для %1$s доступен под различными другими свободными и открытыми <a href=\"%2$s\">лицензиями</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Дополнительный исходный код для %1$s доступен под различными другими "
+"свободными и открытыми <a href=\"%2$s\">лицензиями</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1038,10 +1133,14 @@ msgstr "Дополнительный исходный код для %1$s дос�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s также использует списки блокировки от Disconnect, Inc. как отдельные и независимые работы на условиях <a href=\"%2$s\">Генеральной публичной лицензии GNU версии 3</a>, доступные <a "
-"href=\"%3$s\">здесь</a>."
+"%1$s также использует списки блокировки от Disconnect, Inc. как отдельные"
+" и независимые работы на условиях <a href=\"%2$s\">Генеральной публичной "
+"лицензии GNU версии 3</a>, доступные <a href=\"%3$s\">здесь</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1213,26 +1312,36 @@ msgstr "Ваши скриншоты здесь!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "Чтобы улучшить качество работы, мы собираем информацию о категориях ваших скриншотов."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"Чтобы улучшить качество работы, мы собираем информацию о категориях ваших"
+" скриншотов."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "7-дневный бесплатный VPN готов для Вас. Установите сейчас, чтобы сёрфить более конфиденциально и надежно."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"7-дневный бесплатный VPN готов для Вас. Установите сейчас, чтобы сёрфить "
+"более конфиденциально и надежно."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Мы планируем добавить “Бесплатный поиск WiFi”, чтобы помочь вам найти поблизости качественное бесплатное подключение к Интернету.\n"
+"Мы планируем добавить “Бесплатный поиск WiFi”, чтобы помочь вам найти "
+"поблизости качественное бесплатное подключение к Интернету.\n"
 "\n"
 " Заинтересовались?"
 
@@ -1241,11 +1350,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Мы планируем добавить “VPN сервис”, чтобы дать вам больше свободы и конфиденциальности при сёрфинге.\n"
+"Мы планируем добавить “VPN сервис”, чтобы дать вам больше свободы и "
+"конфиденциальности при сёрфинге.\n"
 "\n"
 " Заинтересовались?"
 
@@ -1267,3 +1378,4 @@ msgstr "ДА, ПОЖАЛУЙСТА"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "НЕТ"
+

--- a/locales/su/app.po
+++ b/locales/su/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-20 03:19+0000\n"
 "Last-Translator: kumincir <ia.adnan@gmail.com>\n"
 "Language: su\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -139,11 +139,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Iber Salindungan"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -467,16 +473,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/su/app.po
+++ b/locales/su/app.po
@@ -2,24 +2,23 @@
 # Copyright (C) 2018 Mozilla
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-20 03:19+0000\n"
 "Last-Translator: kumincir <ia.adnan@gmail.com>\n"
+"Language: su\n"
 "Language-Team: su <LL@li.org>\n"
 "\n"
-"Language: su\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -117,8 +116,12 @@ msgstr "Paluruh di Firefox Lite"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s téh panyungsi anu gancang tur hampang karya %2$s. Ari udaganana nya éta pikeun ngarojong internét nembrak anu séhat."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s téh panyungsi anu gancang tur hampang karya %2$s. Ari udaganana nya "
+"éta pikeun ngarojong internét nembrak anu séhat."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -135,6 +138,16 @@ msgstr "Hak Anjeun / Lisénsi"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Iber Salindungan"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -155,6 +168,11 @@ msgstr "Bawaan sistem"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Mesin pamaluruh baku"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -197,8 +215,12 @@ msgstr "Kirim data pamakéan"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s bakal kukumpul data nu diperlukeun hungkul jang nyadiakeun jeung ngoméan %1$s pikeun anjeun."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s bakal kukumpul data nu diperlukeun hungkul jang nyadiakeun jeung "
+"ngoméan %1$s pikeun anjeun."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -308,8 +330,12 @@ msgstr "Téangan aplikasi nu bisa muka tutumbu"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Euweuh aplikasi nu bisa muka ieu tutumbu. Anjeun bisa ninggalkeun %1$s pikeun maluruh aplikasi nu bisa di %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Euweuh aplikasi nu bisa muka ieu tutumbu. Anjeun bisa ninggalkeun %1$s "
+"pikeun maluruh aplikasi nu bisa di %2$s."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -383,39 +409,75 @@ msgstr "Nuhun geus milih %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "Panyungsi nu dijieun ku %1$s, organisasi tanpabati anu tuhu kana wéb bébas tur nembrak."
+msgstr ""
+"Panyungsi nu dijieun ku %1$s, organisasi tanpabati anu tuhu kana wéb "
+"bébas tur nembrak."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "Ngalanglang sakedét nétra"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "Paké modeu turbo pikeun meungpeuk iklan palacak sangkan anjeun bisa ngalanglang kalawan gancang pisan. Mun situs aya masalah, pareuman baé modeu turbona liwat menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"Paké modeu turbo pikeun meungpeuk iklan palacak sangkan anjeun bisa "
+"ngalanglang kalawan gancang pisan. Mun situs aya masalah, pareuman baé "
+"modeu turbona liwat menu."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "Rikrik data = Rikrik duit"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "Rikrik ongkos data ku cara meungpeuk iklan palacak. Leuwih irit deui lamun ngahirupkeun peungpeuk gambar."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"Rikrik ongkos data ku cara meungpeuk iklan palacak. Leuwih irit deui "
+"lamun ngahirupkeun peungpeuk gambar."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "Téwak layar sakabéhna"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "Téwak layar saeusi kaca. Baca eusina sacara oflén tanpa maké data atawa toél pikeun nyorang deui kaca raramatna."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"Téwak layar saeusi kaca. Baca eusina sacara oflén tanpa maké data atawa "
+"toél pikeun nyorang deui kaca raramatna."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "Privasi tingkat lanjut"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "Nyungsi tanpa tapak, sarta meungpeuk sarupaning palacak raramat sacara baku. Ngajamin amanna data penting anjeun."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"Nyungsi tanpa tapak, sarta meungpeuk sarupaning palacak raramat sacara "
+"baku. Ngajamin amanna data penting anjeun."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -428,8 +490,12 @@ msgstr "Midang dina wanda anyar!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "Luyu jeung kamekaran produkna, kasanggakeun pidangan %1$s anu anyar, kalawan ngaran jeung logo anyar."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"Luyu jeung kamekaran produkna, kasanggakeun pidangan %1$s anu anyar, "
+"kalawan ngaran jeung logo anyar."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -549,8 +615,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "Perenah teu sayaga. Idinan pikeun ngaksés perenah anjeun."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "Paneundeunan teu sayaga. Idinan pikeun nyimpen sarupaning foto jeung koropak na parangkat anjeun."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"Paneundeunan teu sayaga. Idinan pikeun nyimpen sarupaning foto jeung "
+"koropak na parangkat anjeun."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -787,7 +857,9 @@ msgstr "BAGIKEUN"
 #. Snack bar message
 msgctxt "message_fallback_save_to_primary_external"
 msgid "No SD card detected. File was saved to internal storage."
-msgstr "Teu aya kartu mémori kadéték. Koropak geus diteundeun kana paneundeunan internal."
+msgstr ""
+"Teu aya kartu mémori kadéték. Koropak geus diteundeun kana paneundeunan "
+"internal."
 
 msgctxt "message_start_to_save_to_removable_storage"
 msgid "File saved to SD card"
@@ -937,8 +1009,13 @@ msgid "Product Update Notice"
 msgstr "Iber Apdétan Prodak"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Ngarah Firefox Lite leuwih hadé pikeun anjeun jeung balaréa, kami nyieun sawatara parobahan kana kawijakan salindungan kami. Toél baé pikeun leuwih teleb."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Ngarah Firefox Lite leuwih hadé pikeun anjeun jeung balaréa, kami nyieun "
+"sawatara parobahan kana kawijakan salindungan kami. Toél baé pikeun "
+"leuwih teleb."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -950,7 +1027,9 @@ msgstr "Bogoh %1$s?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "Hatur nuhun geus milih prodak kami. Pangdeudeul anjeun kacida utama pikeun kami."
+msgstr ""
+"Hatur nuhun geus milih prodak kami. Pangdeudeul anjeun kacida utama "
+"pikeun kami."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -1001,15 +1080,21 @@ msgstr "Euy, cobaan panyungsi gancang tur hampang ti %3$s. %1$s %2$s"
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s téh aplikasi bébas sarta sumber nembrak nu dijieun ku %2$s jeung kontributor séjénna."
+msgstr ""
+"%1$s téh aplikasi bébas sarta sumber nembrak nu dijieun ku %2$s jeung "
+"kontributor séjénna."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s dijieunna pikeun anjeun kalayan dina pasaratan <a href=\"%2$s\">%3$s</a> jeung lisénsi sumber nembrak nu séjén."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s dijieunna pikeun anjeun kalayan dina pasaratan <a "
+"href=\"%2$s\">%3$s</a> jeung lisénsi sumber nembrak nu séjén."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1018,18 +1103,25 @@ msgstr "%1$s dijieunna pikeun anjeun kalayan dina pasaratan <a href=\"%2$s\">%3$
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"Anjeun teu dibéré idin atawa lisénsi nanaon kana mérek dagang Mozilla Foundation atawa pihak mana ogé, kaasup ngaran atawa logo %3$s, %4$s, atawa %1$s. Émbaran leuwih jero bisa dipanggihan <a "
-"href=\"%2$s\">di dieu</a>."
+"Anjeun teu dibéré idin atawa lisénsi nanaon kana mérek dagang Mozilla "
+"Foundation atawa pihak mana ogé, kaasup ngaran atawa logo %3$s, %4$s, "
+"atawa %1$s. Émbaran leuwih jero bisa dipanggihan <a href=\"%2$s\">di "
+"dieu</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Kodeu sumber tambahan pikeun %1$s nyangkaruk dina rupa-rupa <a href=\"%2$s\">lisénsi</a> bébas jeung sumber nembrak nu séjén."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Kodeu sumber tambahan pikeun %1$s nyangkaruk dina rupa-rupa <a "
+"href=\"%2$s\">lisénsi</a> bébas jeung sumber nembrak nu séjén."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1037,10 +1129,15 @@ msgstr "Kodeu sumber tambahan pikeun %1$s nyangkaruk dina rupa-rupa <a href=\"%2
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s ogé ngagunakeun daptar peungpeukan nu disayagakeun ku Disconnect, Inc. minangka hasil karya nu misah jeung indepénden di handapeun <a href=\"%2$s\">GNU General Public License v3</a>, sarta "
-"sayaga <a href=\"%3$s\">di dieu</a>."
+"%1$s ogé ngagunakeun daptar peungpeukan nu disayagakeun ku Disconnect, "
+"Inc. minangka hasil karya nu misah jeung indepénden di handapeun <a "
+"href=\"%2$s\">GNU General Public License v3</a>, sarta sayaga <a "
+"href=\"%3$s\">di dieu</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1212,26 +1309,36 @@ msgstr "Ilikan téwakan layar anjeun di dieu!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "Pikeun ngaronjatkeun pangalaman produk anjeun, kami kukumpul émbaran ngeunaan kategori téwakan layar anjeun."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"Pikeun ngaronjatkeun pangalaman produk anjeun, kami kukumpul émbaran "
+"ngeunaan kategori téwakan layar anjeun."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "Ladénan VPN bébas 7 poé geus sayaga. Instal ayeuna pikeun ngalanglang leuwih nyamuni tur aman."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"Ladénan VPN bébas 7 poé geus sayaga. Instal ayeuna pikeun ngalanglang "
+"leuwih nyamuni tur aman."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Aya rencana ngahijikeun “Free Wifi-Finder” pikeun mantuan manggihan sambungan internét gratis anu deukeut.\n"
+"Aya rencana ngahijikeun “Free Wifi-Finder” pikeun mantuan manggihan "
+"sambungan internét gratis anu deukeut.\n"
 "\n"
 " Kabita?"
 
@@ -1240,11 +1347,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Aya rencana ngahijikeun “layanan VPN” ngarah kabébasan jeung privasi anjeun nalika nyungsi internét leuwih kajaga.\n"
+"Aya rencana ngahijikeun “layanan VPN” ngarah kabébasan jeung privasi "
+"anjeun nalika nyungsi internét leuwih kajaga.\n"
 "\n"
 "Kabita?"
 
@@ -1266,3 +1375,4 @@ msgstr "MANGGA"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "MOAL"
+

--- a/locales/ta/app.po
+++ b/locales/ta/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-11 05:38+0000\n"
 "Last-Translator: அருண் குமார்|Arun Kumar <thangam.arunx@gmail.com>\n"
 "Language: ta\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,6 +138,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "தனியுரிமை அறிவிப்பு"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -157,6 +167,11 @@ msgstr "கருவி முன்னிருப்பு"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "முன்னிருப்பு தேடுபொறி"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -446,6 +461,23 @@ msgstr ""
 "ஒரு தடத்தை இல்லாமல் உலாவுங்கள், மற்றும் முன்னிருப்பாக பொதுவான வலை "
 "டிராக்கர்களின் பரவலான தடுப்பு. உங்கள் ரகசியத் தரவின் பாதுகாப்பை "
 "உறுதிசெய்யவும்."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"

--- a/locales/ta/app.po
+++ b/locales/ta/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-11 05:38+0000\n"
 "Last-Translator: அருண் குமார்|Arun Kumar <thangam.arunx@gmail.com>\n"
 "Language: ta\n"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "தனியுரிமை அறிவிப்பு"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -467,16 +473,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/te/app.po
+++ b/locales/te/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2018-11-23 08:39+0000\n"
 "Last-Translator: వీవెన్ <veeven@gmail.com>\n"
 "Language: te\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,6 +138,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "గోప్యతా విధానం"
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -157,6 +167,11 @@ msgstr "వ్యవస్థ అప్రమేయం"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "అప్రమేయ శోధన యంత్రం"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -444,6 +459,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/te/app.po
+++ b/locales/te/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2018-11-23 08:39+0000\n"
 "Last-Translator: వీవెన్ <veeven@gmail.com>\n"
 "Language: te\n"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "గోప్యతా విధానం"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -466,16 +472,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/templates/app.pot
+++ b/locales/templates/app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,11 +134,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr ""
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -447,16 +453,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/templates/app.pot
+++ b/locales/templates/app.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -134,6 +134,16 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr ""
 
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
+
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
 msgid "Default search engine"
@@ -152,6 +162,11 @@ msgstr ""
 #. This is the title of the dialog for selecting a new default search engine
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
+msgstr ""
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
 msgstr ""
 
 msgctxt "preference_data_saving_block_images"
@@ -425,6 +440,23 @@ msgctxt "first_run_page5_text"
 msgid ""
 "Browse without a trace, and block a wide range of common web trackers by "
 "default. Ensure the security of your confidential data."
+msgstr ""
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/th/app.po
+++ b/locales/th/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-23 05:35+0000\n"
 "Last-Translator: Top <teerapatxtop@yahoo.com>\n"
-"Language-Team: th <LL@li.org>\n"
 "Language: th\n"
+"Language-Team: th <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "ค้นหาใน Firefox Lite"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s เป็นเบราว์เซอร์ที่เร็วและเบาที่สร้างขึ้นโดย %2$s ภารกิจของเราคือส่งเสริมอินเทอร์เน็ตที่สมบูรณ์และเปิดกว้าง"
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s เป็นเบราว์เซอร์ที่เร็วและเบาที่สร้างขึ้นโดย %2$s "
+"ภารกิจของเราคือส่งเสริมอินเทอร์เน็ตที่สมบูรณ์และเปิดกว้าง"
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "สิทธิของคุณ / สัญญาอนุญาต"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ประกาศความเป็นส่วนตัว"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "ค่าเริ่มต้นของระบบ"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "เครื่องมือค้นหาเริ่มต้น"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "ส่งข้อมูลการใช้งาน"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s มุ่งมั่นที่จะเก็บรวบรวมเฉพาะสิ่งที่เราจำเป็นต้องให้บริการและปรับปรุง %1$s สำหรับทุกคน"
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s มุ่งมั่นที่จะเก็บรวบรวมเฉพาะสิ่งที่เราจำเป็นต้องให้บริการและปรับปรุง"
+" %1$s สำหรับทุกคน"
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "ค้นหาแอปที่สามารถเปิดลิง
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "ไม่มีแอปในอุปกรณ์ของคุณที่สามารถเปิดลิงก์นี้ คุณสามารถออกจาก %1$s เพื่อค้นหา %2$s สำหรับแอปที่สามารถทำได้"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"ไม่มีแอปในอุปกรณ์ของคุณที่สามารถเปิดลิงก์นี้ คุณสามารถออกจาก %1$s "
+"เพื่อค้นหา %2$s สำหรับแอปที่สามารถทำได้"
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -382,39 +408,76 @@ msgstr "ขอบคุณที่เลือก %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "เบราว์เซอร์ที่สร้างขึ้นโดย %1$s องค์กรไม่แสวงหาผลกำไรที่มุ่งมั่นเพื่อเว็บเสรีและเปิดกว้าง"
+msgstr ""
+"เบราว์เซอร์ที่สร้างขึ้นโดย %1$s "
+"องค์กรไม่แสวงหาผลกำไรที่มุ่งมั่นเพื่อเว็บเสรีและเปิดกว้าง"
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "ท่องเว็บได้เร็วขึ้นกว่าที่เคย"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "ใช้โหมดเทอร์โบเพื่อปิดกั้นโฆษณาที่ติดตามข้อมูลของคุณ ทำให้เปิดเว็บได้อย่างรวดเร็ว; ถ้าเว็บไซต์ทำงานผิดปกติ ก็สามารถแตะปิดโหมดเทอร์โบในเมนูได้"
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"ใช้โหมดเทอร์โบเพื่อปิดกั้นโฆษณาที่ติดตามข้อมูลของคุณ "
+"ทำให้เปิดเว็บได้อย่างรวดเร็ว; ถ้าเว็บไซต์ทำงานผิดปกติ "
+"ก็สามารถแตะปิดโหมดเทอร์โบในเมนูได้"
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "ประหยัดข้อมูล = ประหยัดเงิน"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "ประหยัดค่าใช้จ่ายข้อมูลโดยปิดกั้นโฆษณาที่ติดตาม ประหยัดมากยิ่งขึ้นเมื่อคุณเปิดใช้งานการปิดกั้นภาพ"
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"ประหยัดค่าใช้จ่ายข้อมูลโดยปิดกั้นโฆษณาที่ติดตาม "
+"ประหยัดมากยิ่งขึ้นเมื่อคุณเปิดใช้งานการปิดกั้นภาพ"
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "จับภาพหน้าจอทั้งหน้า"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "จับภาพหน้าจอส่วนที่เลื่อนทั้งหน้า อ่านภาพหน้าจอออฟไลน์โดยไม่ต้องใช้ข้อมูลหรือแตะภาพหน้าจอเพื่อเยี่ยมชมหน้าเว็บใหม่"
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"จับภาพหน้าจอส่วนที่เลื่อนทั้งหน้า "
+"อ่านภาพหน้าจอออฟไลน์โดยไม่ต้องใช้ข้อมูลหรือแตะภาพหน้าจอเพื่อเยี่ยมชมหน้าเว็บใหม่"
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "ความเป็นส่วนตัวระดับถัดไป"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "ท่องเว็บโดยไม่มีร่องรอย และปิดกั้นตัวติดตามเว็บทั่วไปจำนวนมากโดยค่าเริ่มต้น ทำให้มั่นใจในความปลอดภัยของข้อมูลที่เป็นความลับของคุณ"
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"ท่องเว็บโดยไม่มีร่องรอย "
+"และปิดกั้นตัวติดตามเว็บทั่วไปจำนวนมากโดยค่าเริ่มต้น "
+"ทำให้มั่นใจในความปลอดภัยของข้อมูลที่เป็นความลับของคุณ"
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +490,12 @@ msgstr "เรามีหน้าตาใหม่!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "ด้วยผลิตภัณฑ์ที่ได้รับการพัฒนา เรานำ %1$s แบบใหม่พร้อมชื่อใหม่และโลโก้ใหม่มาให้คุณ"
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"ด้วยผลิตภัณฑ์ที่ได้รับการพัฒนา เรานำ %1$s "
+"แบบใหม่พร้อมชื่อใหม่และโลโก้ใหม่มาให้คุณ"
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,7 +615,9 @@ msgid "Location not available. Give permission to access your location."
 msgstr "ตำแหน่งที่ตั้งไม่พร้อมใช้งาน อนุญาตให้เข้าถึงตำแหน่งที่ตั้งของคุณ"
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
 msgstr "ที่เก็บข้อมูลไม่พร้อมใช้งาน อนุญาตให้เก็บภาพและไฟล์ในอุปกรณ์ของคุณ"
 
 #. When the webpage request access to geolocation a dialog will popup.
@@ -932,8 +1001,13 @@ msgid "Product Update Notice"
 msgstr "ประกาศการอัปเดตผลิตภัณฑ์"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "เพื่อทำให้ Firefox Lite ดีขึ้นสำหรับคุณและทุกคน เราได้ทำการเปลี่ยนแปลงบางอย่างกับนโยบายความเป็นส่วนตัวของเรา แตะเพื่อเรียนรู้เพิ่มเติม"
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"เพื่อทำให้ Firefox Lite ดีขึ้นสำหรับคุณและทุกคน "
+"เราได้ทำการเปลี่ยนแปลงบางอย่างกับนโยบายความเป็นส่วนตัวของเรา "
+"แตะเพื่อเรียนรู้เพิ่มเติม"
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -996,15 +1070,21 @@ msgstr "เฮ้ ลองดูเบราว์เซอร์ที่เ�
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s เป็นซอฟต์แวร์เสรีและเปิดต้นฉบับที่สร้างขึ้นโดย %2$s และผู้มีส่วนร่วมอื่น ๆ"
+msgstr ""
+"%1$s เป็นซอฟต์แวร์เสรีและเปิดต้นฉบับที่สร้างขึ้นโดย %2$s "
+"และผู้มีส่วนร่วมอื่น ๆ"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s ให้คุณใช้ภายใต้เงื่อนไขของ <a href=\"%2$s\">%3$s</a> และสัญญาอนุญาตการเปิดต้นฉบับอื่น ๆ"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s ให้คุณใช้ภายใต้เงื่อนไขของ <a href=\"%2$s\">%3$s</a> "
+"และสัญญาอนุญาตการเปิดต้นฉบับอื่น ๆ"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1013,16 +1093,24 @@ msgstr "%1$s ให้คุณใช้ภายใต้เงื่อนไ�
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
-msgstr "คุณไม่ได้รับสิทธิหรือสัญญาอนุญาตใด ๆ ในเครื่องหมายการค้าของมูลนิธิ Mozilla หรือบุคคลใด ๆ รวมทั้งชื่อหรือโลโก้ %3$s, %4$s หรือ %1$s ข้อมูลเพิ่มเติมอาจพบได้ <a href=\"%2$s\">ที่นี่</a>"
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
+msgstr ""
+"คุณไม่ได้รับสิทธิหรือสัญญาอนุญาตใด ๆ ในเครื่องหมายการค้าของมูลนิธิ "
+"Mozilla หรือบุคคลใด ๆ รวมทั้งชื่อหรือโลโก้ %3$s, %4$s หรือ %1$s "
+"ข้อมูลเพิ่มเติมอาจพบได้ <a href=\"%2$s\">ที่นี่</a>"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "โค้ดต้นฉบับเพิ่มเติมสำหรับ %1$s ใช้ได้ภายใต้ <a href=\"%2$s\">สัญญาอนุญาต</a> เสรีและเปิดต้นฉบับต่าง ๆ"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"โค้ดต้นฉบับเพิ่มเติมสำหรับ %1$s ใช้ได้ภายใต้ <a "
+"href=\"%2$s\">สัญญาอนุญาต</a> เสรีและเปิดต้นฉบับต่าง ๆ"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1030,8 +1118,14 @@ msgstr "โค้ดต้นฉบับเพิ่มเติมสำหร
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s ยังใช้รายการปิดกั้นที่ให้บริการโดย Disconnect, Inc. ซึ่งเป็นงานแยกและเป็นอิสระภายใต้ <a href=\"%2$s\">GNU General Public License v3</a> และใช้ได้ <a href=\"%3$s\">ที่นี่</a>"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s ยังใช้รายการปิดกั้นที่ให้บริการโดย Disconnect, Inc. "
+"ซึ่งเป็นงานแยกและเป็นอิสระภายใต้ <a href=\"%2$s\">GNU General Public "
+"License v3</a> และใช้ได้ <a href=\"%3$s\">ที่นี่</a>"
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1201,26 +1295,36 @@ msgstr "ดูภาพหน้าจอของคุณที่นี่!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "เพื่อปรับปรุงประสบการณ์ผลิตภัณฑ์ของคุณ เราเก็บรวบรวมข้อมูลเกี่ยวกับหมวดหมู่ของภาพหน้าจอของคุณ"
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"เพื่อปรับปรุงประสบการณ์ผลิตภัณฑ์ของคุณ "
+"เราเก็บรวบรวมข้อมูลเกี่ยวกับหมวดหมู่ของภาพหน้าจอของคุณ"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "บริการ VPN ฟรี 7 วันพร้อมแล้วสำหรับคุณ ติดตั้งตอนนี้เพื่อท่องเว็บอย่างเป็นส่วนตัวและปลอดภัยมากขึ้น"
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"บริการ VPN ฟรี 7 วันพร้อมแล้วสำหรับคุณ "
+"ติดตั้งตอนนี้เพื่อท่องเว็บอย่างเป็นส่วนตัวและปลอดภัยมากขึ้น"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"เราวางแผนที่จะผนวกรวม “ตัวค้นหา Wifi ฟรี” เพื่อช่วยคุณค้นหาการเชื่อมต่ออินเทอร์เน็ตฟรีที่มีคุณภาพที่อยู่ใกล้เคียง\n"
+"เราวางแผนที่จะผนวกรวม “ตัวค้นหา Wifi ฟรี” "
+"เพื่อช่วยคุณค้นหาการเชื่อมต่ออินเทอร์เน็ตฟรีที่มีคุณภาพที่อยู่ใกล้เคียง\n"
 "\n"
 " สนใจไหม?"
 
@@ -1229,11 +1333,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"เราวางแผนที่จะผนวกรวม “บริการ VPN” เพื่อให้คุณมีอิสรภาพมากขึ้นและความเป็นส่วนตัวเพิ่มขึ้นเมื่อท่องเว็บ\n"
+"เราวางแผนที่จะผนวกรวม “บริการ VPN” "
+"เพื่อให้คุณมีอิสรภาพมากขึ้นและความเป็นส่วนตัวเพิ่มขึ้นเมื่อท่องเว็บ\n"
 "\n"
 " สนใจไหม?"
 
@@ -1255,3 +1361,4 @@ msgstr "ใช่ ได้โปรด"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "ไม่"
+

--- a/locales/th/app.po
+++ b/locales/th/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-23 05:35+0000\n"
 "Last-Translator: Top <teerapatxtop@yahoo.com>\n"
 "Language: th\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "ประกาศความเป็นส่วนตัว"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -467,16 +473,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/tl/app.po
+++ b/locales/tl/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-24 12:53+0000\n"
 "Last-Translator: Bob Reyes <robert.reyes@gmail.com>\n"
 "Language: fil_PH\n"
@@ -20,7 +20,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -141,11 +141,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Abiso sa Privacy"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -473,16 +479,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/tl/app.po
+++ b/locales/tl/app.po
@@ -2,23 +2,25 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-24 12:53+0000\n"
 "Last-Translator: Bob Reyes <robert.reyes@gmail.com>\n"
+"Language: fil_PH\n"
 "Language-Team: fil_PH <LL@li.org>\n"
-"Language: tl\n"
+"Plural-Forms: nplurals=2; plural=((((((0 == 0)) && ((n == 1) || (n == 2) "
+"|| (n == 3))) || (((0 == 0)) && (!(((n % 10) == 4) || ((n % 10) == 6) || "
+"((n % 10) == 9))))) || ((!((0 == 0))) && (!(((0 % 10) == 4) || ((0 % 10) "
+"== 6) || ((0 % 10) == 9))))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 3) && (n%10 == 4 || n%10 == 6 || n%10 == 9);\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +118,12 @@ msgstr "Hanapin sa Firefox Rocket"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s ay isang mabilis at magaan na browser na gawa ng %2$s. Ang aming misyon ay mapanatiling malusog at bukas para sa lahat ang internet."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s ay isang mabilis at magaan na browser na gawa ng %2$s. Ang aming "
+"misyon ay mapanatiling malusog at bukas para sa lahat ang internet."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +140,16 @@ msgstr "Ang Iyong mga Karapatan / Lisensya"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Abiso sa Privacy"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +170,11 @@ msgstr "Default sa sistema"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Default na search engine"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +217,12 @@ msgstr "Ipadala ang mga datos ng paggamit"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "Nagsusumikap ang %2$s na kumulekta lamang ng mga impormasyon base sa pangangailangan upang mapagbuti ang %1$s para sa lahat."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"Nagsusumikap ang %2$s na kumulekta lamang ng mga impormasyon base sa "
+"pangangailangan upang mapagbuti ang %1$s para sa lahat."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +332,13 @@ msgstr "Hanapin ang app na maaaring magbukas ng link"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Walang app sa iyong device na maaaring magbukas ng link na ito. Maaarin mong iwan ang %1$s para maghanap ang %2$s ng app na maaaring magbukas ng link na ito."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Walang app sa iyong device na maaaring magbukas ng link na ito. Maaarin "
+"mong iwan ang %1$s para maghanap ang %2$s ng app na maaaring magbukas ng "
+"link na ito."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -333,7 +363,9 @@ msgstr "Hindi maintindihan ang address"
 
 msgctxt "error_page_content_text_unsupported_scheme"
 msgid "You might need to install other software to open this address."
-msgstr "Kinakailangang mag-install ng karagdagang software para mabuksan ang address na ito."
+msgstr ""
+"Kinakailangang mag-install ng karagdagang software para mabuksan ang "
+"address na ito."
 
 #. Label used in the contextmenu shown when long-pressing on a link
 msgctxt "contextmenu_link_share"
@@ -382,41 +414,76 @@ msgstr "Salamat sa pagpili ng %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "Ang browser na sadyang ginawa para sa Pilipinas mula sa %1$s, ang non-profit na nagtataguyod ng isang malaya at bukas na web."
+msgstr ""
+"Ang browser na sadyang ginawa para sa Pilipinas mula sa %1$s, ang non-"
+"profit na nagtataguyod ng isang malaya at bukas na web."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "Mag-browse nang mas matulin"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
 msgstr ""
-"Gamitin ang turbo mode para harangin ang mga tracking ads at para makapag-browse nang mas matulin. Kung hindi lalabas ng tama ang mga website, i-tap lang ang turbo mode mula sa menu para ito ay mag-"
-"off."
+"Gamitin ang turbo mode para harangin ang mga tracking ads at para "
+"makapag-browse nang mas matulin. Kung hindi lalabas ng tama ang mga "
+"website, i-tap lang ang turbo mode mula sa menu para ito ay mag-off."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "Naipong data = Naipong pera"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "Makakatipid ka ng data sa pagharang sa tracking ads. May Karagdagang katipiran kung gagamit din ng image blocking."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"Makakatipid ka ng data sa pagharang sa tracking ads. May Karagdagang "
+"katipiran kung gagamit din ng image blocking."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "I-screenshot ang buong pahina"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "Kunin ang screenshot ng buong pahina. Tingnan ang screenshot offline ng hindi gagamit ng data o kaya ay i-tap ito para puntahan ang web page."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"Kunin ang screenshot ng buong pahina. Tingnan ang screenshot offline ng "
+"hindi gagamit ng data o kaya ay i-tap ito para puntahan ang web page."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "Susunod na antas ng privacy"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "Mag-browse nang walang bakas, at i-block ang isang malawak na hanay ng mga karaniwang trackers sa web bilang default. Tiyakin ang seguridad ng iyong kumpidensyal na data."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"Mag-browse nang walang bakas, at i-block ang isang malawak na hanay ng "
+"mga karaniwang trackers sa web bilang default. Tiyakin ang seguridad ng "
+"iyong kumpidensyal na data."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -429,8 +496,12 @@ msgstr "Mayroon kaming bagong hitsura!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "Sa paglaki ng produkto, dalhin namin sa iyo ang isang bagong na-refresh na %1$s, na may bagong pangalan at bagong logo."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"Sa paglaki ng produkto, dalhin namin sa iyo ang isang bagong na-refresh "
+"na %1$s, na may bagong pangalan at bagong logo."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -448,7 +519,9 @@ msgstr "maraming mga tab"
 #, c-format, python-format
 msgctxt "first_run_upgrade_page_text2"
 msgid "2. Access your favorite sites quickly by %s"
-msgstr "2. Puntahan ang iyong mga paboritong website nang mas mabilis sa pamamagitan ng %s"
+msgstr ""
+"2. Puntahan ang iyong mga paboritong website nang mas mabilis sa "
+"pamamagitan ng %s"
 
 msgctxt "first_run_upgrade_page_text2_highlight"
 msgid "adding them to the home screen!"
@@ -547,11 +620,17 @@ msgstr "huwag ngayon"
 
 msgctxt "permission_toast_location"
 msgid "Location not available. Give permission to access your location."
-msgstr "Hindi makita ang iyong lokasyon. Pakibigyan ng pahintulot ang app na malaman ang iyong lokasyon."
+msgstr ""
+"Hindi makita ang iyong lokasyon. Pakibigyan ng pahintulot ang app na "
+"malaman ang iyong lokasyon."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "Hindi magamit ang sisidlan. Pakibigyan ng pahintulot ang app na magamit ang sisidlan para makapagtago ng mga larawan at files sa iyong device."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"Hindi magamit ang sisidlan. Pakibigyan ng pahintulot ang app na magamit "
+"ang sisidlan para makapagtago ng mga larawan at files sa iyong device."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -796,7 +875,9 @@ msgstr "Nasa SD card na ang file"
 
 msgctxt "message_removable_storage_space_not_enough"
 msgid "SD card is almost full. File was saved to internal storage."
-msgstr "Halos puno na ang iyong SD card. Ang file ay hindi nai-save sa internal storage."
+msgstr ""
+"Halos puno na ang iyong SD card. Ang file ay hindi nai-save sa internal "
+"storage."
 
 #. ScreenshotGridFragment
 msgctxt "screenshot_grid_empty_text_title"
@@ -938,8 +1019,13 @@ msgid "Product Update Notice"
 msgstr "Abiso sa Update ng Produkto"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Upang gawing mas mahusay ang Firefox Lite para sa iyo at sa lahat, gumawa kami ng ilang mga pagbabago sa aming patakaran sa privacy. Tapikin upang matuto nang higit pa."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Upang gawing mas mahusay ang Firefox Lite para sa iyo at sa lahat, gumawa"
+" kami ng ilang mga pagbabago sa aming patakaran sa privacy. Tapikin upang"
+" matuto nang higit pa."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -951,7 +1037,9 @@ msgstr "Naibigan mo ba ang %1$s?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "Maraming salamat sa iyong pagtangkilik sa aming produkto. Ang iyong feedback ay napakahalaga sa amin."
+msgstr ""
+"Maraming salamat sa iyong pagtangkilik sa aming produkto. Ang iyong "
+"feedback ay napakahalaga sa amin."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -1002,15 +1090,21 @@ msgstr "Hoy, tingnan itong mabilis at magaan na browser mula sa %3$s. %1$s %2$s"
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s ay libre at open source na software na gawa ng %2$s at ng iba pang mga taga-ambag."
+msgstr ""
+"%1$s ay libre at open source na software na gawa ng %2$s at ng iba pang "
+"mga taga-ambag."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s ay gawa mula sa mga panuntunan ng <a href=\"%2$s\">%3$s</a> at iba pang open source na mga lisensya."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s ay gawa mula sa mga panuntunan ng <a href=\"%2$s\">%3$s</a> at iba "
+"pang open source na mga lisensya."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1019,18 +1113,24 @@ msgstr "%1$s ay gawa mula sa mga panuntunan ng <a href=\"%2$s\">%3$s</a> at iba 
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1038,8 +1138,14 @@ msgstr "Additional source code for %1$s is available under various other free an
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s ay gumagamit din ng blocklists mula sa Disconnect, Inc. na kabilang sa <a href=\"%2$s\">GNU General Public License v3</a>, at makikita <a href=\"%3$s\">dito</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s ay gumagamit din ng blocklists mula sa Disconnect, Inc. na kabilang "
+"sa <a href=\"%2$s\">GNU General Public License v3</a>, at makikita <a "
+"href=\"%3$s\">dito</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1211,26 +1317,36 @@ msgstr "Tingnan ang mga screenshot dito!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "Para mapabuti ang produktong ito, kami ay maaaring mangolekta ng impormasyon tungkol sa iyong screen."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"Para mapabuti ang produktong ito, kami ay maaaring mangolekta ng "
+"impormasyon tungkol sa iyong screen."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "Ang 7-araw na libreng serbisyo ng VPN ay handa na para sa iyo. I-install ngayon upang mag-browse nang mas pribado at ligtas."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"Ang 7-araw na libreng serbisyo ng VPN ay handa na para sa iyo. I-install "
+"ngayon upang mag-browse nang mas pribado at ligtas."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Balak naming magsama ng “Free Wifi-Finder” para makatulong sa paghahanap ng libreng internet connection na malapit sa iyo.\n"
+"Balak naming magsama ng “Free Wifi-Finder” para makatulong sa paghahanap "
+"ng libreng internet connection na malapit sa iyo.\n"
 "\n"
 " Interessado?"
 
@@ -1239,11 +1355,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Balak naming magsama ng “VPN service” para sa mas mainam ng pribasiya habang ikaw ay nagba-browse.\n"
+"Balak naming magsama ng “VPN service” para sa mas mainam ng pribasiya "
+"habang ikaw ay nagba-browse.\n"
 "\n"
 " Interesado?"
 
@@ -1265,3 +1383,4 @@ msgstr "OO"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "HINDI"
+

--- a/locales/vi/app.po
+++ b/locales/vi/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-03-01 05:57+0000\n"
 "Last-Translator: Quế Tùng <best.cloney.1301@gmail.com>\n"
 "Language: vi\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -138,11 +138,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Chính sách riêng tư"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -466,16 +472,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/vi/app.po
+++ b/locales/vi/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-03-01 05:57+0000\n"
 "Last-Translator: Quế Tùng <best.cloney.1301@gmail.com>\n"
-"Language-Team: vi <LL@li.org>\n"
 "Language: vi\n"
+"Language-Team: vi <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,8 +115,12 @@ msgstr "Tìm kiếm trong Firefox Lite"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
-msgstr "%1$s là một trình duyệt nhanh và nhẹ được sản xuất bởi %2$s. Nhiệm vụ của chúng tôi là thúc đẩy một mạng internet mở, lành mạnh."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
+msgstr ""
+"%1$s là một trình duyệt nhanh và nhẹ được sản xuất bởi %2$s. "
+"Nhiệm vụ của chúng tôi là thúc đẩy một mạng internet mở, lành mạnh."
 
 msgctxt "about_link_learn_more"
 msgid "Learn more"
@@ -134,6 +137,16 @@ msgstr "Quyền lợi của bạn / Giấy phép"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "Chính sách riêng tư"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +167,11 @@ msgstr "Mặc định hệ thống"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "Công cụ tìm kiếm mặc định"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,8 +214,12 @@ msgstr "Gửi dữ liệu sử dụng"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
-msgstr "%2$s cố gắng chỉ thu thập những gì chúng tôi cần cung cấp và cải thiện %1$s cho mọi người."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
+msgstr ""
+"%2$s cố gắng chỉ thu thập những gì chúng tôi cần cung cấp và cải thiện "
+"%1$s cho mọi người."
 
 msgctxt "preference_learn_more"
 msgid "Learn more"
@@ -307,8 +329,12 @@ msgstr "Tìm ứng dụng có thể mở liên kết này"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Không có ứng dụng nào trên thiết bị của bạn có thể mở liên kết này. Bạn có thể rời khỏi %1$s để tìm ứng dụng có thể mở %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Không có ứng dụng nào trên thiết bị của bạn có thể mở liên kết này. Bạn "
+"có thể rời khỏi %1$s để tìm ứng dụng có thể mở %2$s."
 
 #. The page html title (i.e. the <title> tag content)
 msgctxt "error_page_title"
@@ -382,39 +408,75 @@ msgstr "Cảm ơn bạn đã chọn %1$s"
 #, c-format
 msgctxt "first_run_page1_text"
 msgid "A browser made by %1$s, the non-profit committed to a free and open web."
-msgstr "Một trình duyệt được tạo bởi %1$s, phi lợi nhuận đã cam kết với một trang web mở và miễn phí."
+msgstr ""
+"Một trình duyệt được tạo bởi %1$s, phi lợi nhuận đã cam kết với một trang"
+" web mở và miễn phí."
 
 msgctxt "first_run_page2_title"
 msgid "Browse faster than ever"
 msgstr "Duyệt nhanh hơn bao giờ hết"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
-msgstr "Sử dụng chế độ turbo để chặn quảng cáo theo dõi để bạn và có thể duyệt ở tốc độ nhanh. Nếu các trang web có vẻ bị hỏng, chỉ cần nhấn vào công tắc của chế độ turbo trong menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
+msgstr ""
+"Sử dụng chế độ turbo để chặn quảng cáo theo dõi để bạn và có thể duyệt ở "
+"tốc độ nhanh. Nếu các trang web có vẻ bị hỏng, chỉ cần nhấn vào công tắc "
+"của chế độ turbo trong menu."
 
 msgctxt "first_run_page3_title"
 msgid "Save data = Save money"
 msgstr "Lưu dữ liệu = Tiết kiệm tiền"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
-msgstr "Tiết kiệm chi phí dữ liệu bằng cách chặn quảng cáo. Tiết kiệm hơn nữa khi bạn kích hoạt chặn hình ảnh."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
+msgstr ""
+"Tiết kiệm chi phí dữ liệu bằng cách chặn quảng cáo. Tiết kiệm hơn nữa khi"
+" bạn kích hoạt chặn hình ảnh."
 
 msgctxt "first_run_page4_title"
 msgid "Screenshot the whole page"
 msgstr "Ảnh chụp màn hình toàn bộ trang"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
-msgstr "Chụp ảnh màn hình của toàn bộ trang. Đọc ngoại tuyến mà không sử dụng dữ liệu hoặc chạm vào nó để xem lại trang web."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
+msgstr ""
+"Chụp ảnh màn hình của toàn bộ trang. Đọc ngoại tuyến mà không sử dụng dữ "
+"liệu hoặc chạm vào nó để xem lại trang web."
 
 msgctxt "first_run_page5_title"
 msgid "Next-level privacy"
 msgstr "Quyền riêng tư cấp độ tiếp theo"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
-msgstr "Duyệt mà không để lại dấu vết và chặn một loạt các trình theo dõi web phổ biến theo mặc định. Đảm bảo an toàn cho dữ liệu bí mật của bạn."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
+msgstr ""
+"Duyệt mà không để lại dấu vết và chặn một loạt các trình theo dõi web phổ"
+" biến theo mặc định. Đảm bảo an toàn cho dữ liệu bí mật của bạn."
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,8 +489,12 @@ msgstr "Chúng tôi có một cái nhìn mới!"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
-msgstr "Với sản phẩm đã phát triển, chúng tôi mang đến cho bạn một %1$s mới mẻ, với tên mới và logo mới."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
+msgstr ""
+"Với sản phẩm đã phát triển, chúng tôi mang đến cho bạn một %1$s mới mẻ,"
+" với tên mới và logo mới."
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
 #. first_run_upgrade_page_text1_highlight)
@@ -548,8 +614,12 @@ msgid "Location not available. Give permission to access your location."
 msgstr "Địa điểm không có sẵn. Cho phép để truy cập vị trí của bạn."
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
-msgstr "Lưu trữ không có sẵn. Cho phép để lưu trữ ảnh và tập tin trên thiết bị của bạn."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
+msgstr ""
+"Lưu trữ không có sẵn. Cho phép để lưu trữ ảnh và tập tin trên thiết bị "
+"của bạn."
 
 #. When the webpage request access to geolocation a dialog will popup.
 #. This is the title of the permission request dialog. Argument 1 is the url of
@@ -934,8 +1004,13 @@ msgid "Product Update Notice"
 msgstr "Thông báo cập nhật sản phẩm"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
-msgstr "Để làm cho Firefox Lite tốt hơn cho bạn và mọi người, chúng tôi đã thực hiện một số thay đổi đối với chính sách quyền riêng tư của mình. Nhấn để tìm hiểu thêm."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
+msgstr ""
+"Để làm cho Firefox Lite tốt hơn cho bạn và mọi người, chúng tôi đã thực "
+"hiện một số thay đổi đối với chính sách quyền riêng tư của mình. Nhấn để "
+"tìm hiểu thêm."
 
 #. In-app Promotion, Rate the App
 #. The title of the Message to prompt users to rate Rocket on Play Store, %1$s
@@ -947,7 +1022,9 @@ msgstr "Thích ứng dụng %1$s?"
 
 msgctxt "rate_app_dialog_text_content"
 msgid "Thank you for choosing our product. Your feedback is important to us."
-msgstr "Cảm ơn bạn đã chọn sản phẩm của chúng tôi. Phản hồi của bạn rất quan trọng với chúng tôi."
+msgstr ""
+"Cảm ơn bạn đã chọn sản phẩm của chúng tôi. Phản hồi của bạn rất quan "
+"trọng với chúng tôi."
 
 msgctxt "rate_app_dialog_btn_go_rate"
 msgid "Rate Us"
@@ -998,15 +1075,21 @@ msgstr "Này, hãy xem trình duyệt nhanh và nhẹ này từ %3$s. %1$s %2$s"
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced by "Mozilla"
 msgctxt "your_rights_content1"
 msgid "%1$s is free and open source software made by %2$s and other contributors."
-msgstr "%1$s là phần mềm nguồn mở và miễn phí được tạo bởi %2$s và những người đóng góp khác."
+msgstr ""
+"%1$s là phần mềm nguồn mở và miễn phí được tạo bởi %2$s và những người "
+"đóng góp khác."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
-msgstr "%1$s được cung cấp cho bạn theo các điều khoản của <a href=\"%2$s\">%3$s</a> và các giấy phép nguồn mở khác."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
+msgstr ""
+"%1$s được cung cấp cho bạn theo các điều khoản của <a "
+"href=\"%2$s\">%3$s</a> và các giấy phép nguồn mở khác."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1015,18 +1098,25 @@ msgstr "%1$s được cung cấp cho bạn theo các điều khoản của <a hr
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
 msgstr ""
-"Bạn không được cấp bất kỳ quyền hoặc giấy phép nào cho các nhãn hiệu của nền tảng Mozilla hoặc bất kỳ bên nào, bao gồm %3$s, %4$s hoặc tên hoặc logo của %1$s. Thông tin bổ sung có thể được tìm "
-"thấy <a href=\"%2$s\"> tại đây </a>."
+"Bạn không được cấp bất kỳ quyền hoặc giấy phép nào cho các nhãn hiệu của "
+"nền tảng Mozilla hoặc bất kỳ bên nào, bao gồm %3$s, %4$s hoặc tên "
+"hoặc logo của %1$s. Thông tin bổ sung có thể được tìm thấy <a "
+"href=\"%2$s\"> tại đây </a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Đoạn mã bổ sung cho %1$s có sẵn dưới nhiều loại <a href=\"%2$s\">giấy phép</a> tự do và nguồn mở khác nhau."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Đoạn mã bổ sung cho %1$s có sẵn dưới nhiều loại <a href=\"%2$s\">giấy "
+"phép</a> tự do và nguồn mở khác nhau."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
@@ -1034,10 +1124,14 @@ msgstr "Đoạn mã bổ sung cho %1$s có sẵn dưới nhiều loại <a href=
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s cũng sử dụng danh sách chặn được cung cấp bởi Disconnect, Inc. là các công việc riêng biệt và độc lập theo <a href=\"%2$s\">GNU General Public License v3</a>, và có sẵn <a href=\"%3$s\">ở "
-"đây</a>."
+"%1$s cũng sử dụng danh sách chặn được cung cấp bởi Disconnect, Inc. là "
+"các công việc riêng biệt và độc lập theo <a href=\"%2$s\">GNU General "
+"Public License v3</a>, và có sẵn <a href=\"%3$s\">ở đây</a>."
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1209,26 +1303,36 @@ msgstr "Xem ảnh chụp màn hình của bạn ở đây!"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
-msgstr "Để cải thiện trải nghiệm sản phẩm của bạn, chúng tôi thu thập thông tin về các loại ảnh chụp màn hình của bạn."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
+msgstr ""
+"Để cải thiện trải nghiệm sản phẩm của bạn, chúng tôi thu thập thông tin "
+"về các loại ảnh chụp màn hình của bạn."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
-msgstr "Dịch vụ VPN miễn phí 7 ngày đã sẵn sàng cho bạn. Cài đặt ngay để duyệt riêng tư và an toàn hơn."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
+msgstr ""
+"Dịch vụ VPN miễn phí 7 ngày đã sẵn sàng cho bạn. Cài đặt ngay để duyệt "
+"riêng tư và an toàn hơn."
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. We'll evaluate if we want to implement this
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Chúng tôi dự định tích hợp miễn phí Wifi-Finder để giúp bạn tìm kết nối internet miễn phí chất lượng cao ở xung quanh.\n"
+"Chúng tôi dự định tích hợp miễn phí Wifi-Finder để giúp bạn tìm kết nối "
+"internet miễn phí chất lượng cao ở xung quanh.\n"
 "\n"
 "Quan tâm?"
 
@@ -1237,11 +1341,13 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
-"Chúng tôi dự định tích hợp dịch vụ VPN để giúp bạn tự do hơn và riêng tư hơn khi duyệt web.\n"
+"Chúng tôi dự định tích hợp dịch vụ VPN để giúp bạn tự do hơn và riêng tư "
+"hơn khi duyệt web.\n"
 " \n"
 "Quan tâm?"
 
@@ -1263,3 +1369,4 @@ msgstr "VÂNG, LÀM ƠN"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "KHÔNG"
+

--- a/locales/zh-CN/app.po
+++ b/locales/zh-CN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-20 02:54+0000\n"
 "Last-Translator: 우믿트 <eloli@foxmail.com>\n"
+"Language: zh_Hans_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,7 +115,9 @@ msgstr "在 Firefox Lite 中搜索"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
 msgstr "%1$s 是由 %2$s 出品的快速而轻量的浏览器。我们以营造健康、开放的互联网为己任。"
 
 msgctxt "about_link_learn_more"
@@ -134,6 +135,16 @@ msgstr "您的权利 / 许可协议"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "隐私声明"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +165,11 @@ msgstr "系统默认"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "默认搜索引擎"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,7 +212,9 @@ msgstr "发送统计数据"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
 msgstr "%2$s 力争仅收集用来为大众改进 %1$s 所必需的数据。"
 
 msgctxt "preference_learn_more"
@@ -307,7 +325,9 @@ msgstr "使用其他应用打开此链接"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "未找到可以打开此链接的应用，可以离开 %1$s 前往 %2$s 搜索其他可打开此链接的应用。"
 
 #. The page html title (i.e. the <title> tag content)
@@ -389,7 +409,9 @@ msgid "Browse faster than ever"
 msgstr "上网快上加快"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
 msgstr "加速模式将过滤广告跟踪，上网更轻快。如果网页有问题，只需在菜单中的关掉加速模式。"
 
 msgctxt "first_run_page3_title"
@@ -397,7 +419,9 @@ msgid "Save data = Save money"
 msgstr "节省流量 = 节省金钱"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
 msgstr "拦截广告跟踪可节省流量，不载入图像还能再省更多。"
 
 msgctxt "first_run_page4_title"
@@ -405,7 +429,9 @@ msgid "Screenshot the whole page"
 msgstr "截取整个页面"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
 msgstr "不但能滚动截取整个网页、离线查看截图（无需流量），还可通过点击截图重新访问原网页。"
 
 msgctxt "first_run_page5_title"
@@ -413,8 +439,27 @@ msgid "Next-level privacy"
 msgstr "新一代隐私权保护"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
 msgstr "无痕浏览。默认阻止各种常见的网络跟踪器。确保私密数据的安全性。"
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,7 +472,9 @@ msgstr "我们焕然一新！"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
 msgstr "随着产品的演化，我们为您带来了焕然一新的 %1$s，新名称、新标志。"
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
@@ -548,7 +595,9 @@ msgid "Location not available. Give permission to access your location."
 msgstr "无法获知您的位置。请授予获取您位置的权限。"
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
 msgstr "无法使用存储。请授予在您的设备上存储照片和文件的权限。"
 
 #. When the webpage request access to geolocation a dialog will popup.
@@ -934,7 +983,9 @@ msgid "Product Update Notice"
 msgstr "产品更新通知"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
 msgstr "为了让 Firefox Lite 更适合您和每个人，我们对隐私政策进行了一些修改。点击以了解更多信息。"
 
 #. In-app Promotion, Rate the App
@@ -1005,7 +1056,9 @@ msgstr "%1$s 是由 %2$s 和其他贡献者提供的自由且开源软件。"
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
 msgstr "%1$s 根据 <a href=\"%2$s\">%3$s</a> 以及其他开源许可证向您提供。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
@@ -1015,15 +1068,20 @@ msgstr "%1$s 根据 <a href=\"%2$s\">%3$s</a> 以及其他开源许可证向您�
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
-msgstr "您没有得到 Mozilla 基金会或任何其他方面（包括 %3$s、%4$s 或 %1$s 的名称或标志）的商标授权。更多信息参见<a href=\"%2$s\">此处</a>。"
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
+msgstr ""
+"您没有得到 Mozilla 基金会或任何其他方面（包括 %3$s、%4$s 或 %1$s 的名称或标志）的商标授权。更多信息参见<a "
+"href=\"%2$s\">此处</a>。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
 msgstr "%1$s 的其他源代码可按各种自由和开源软件<a href=\"%2$s\">许可证</a>使用。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
@@ -1032,8 +1090,13 @@ msgstr "%1$s 的其他源代码可按各种自由和开源软件<a href=\"%2$s\"
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s 还使用 Disconnect 公司提供的黑名单，该黑名单为该公司的独立作品，按 <a href=\"%2$s\">GNU 通用公共许可证第三版</a>提供，可在<a href=\"%3$s\">这里</a>找到。"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s 还使用 Disconnect 公司提供的黑名单，该黑名单为该公司的独立作品，按 <a href=\"%2$s\">GNU "
+"通用公共许可证第三版</a>提供，可在<a href=\"%3$s\">这里</a>找到。"
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1205,14 +1268,18 @@ msgstr "在这里查看您的截图！"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
 msgstr "为了改善您的产品体验，我们会收集有关您的屏幕截图类别的信息。"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
 msgstr "VPN 服务 7 天免费使用。立即安装，上网可以更私密、更安全。"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
@@ -1220,7 +1287,8 @@ msgstr "VPN 服务 7 天免费使用。立即安装，上网可以更私密、�
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
@@ -1233,7 +1301,8 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
@@ -1259,3 +1328,4 @@ msgstr "是的，我想要"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "不需要"
+

--- a/locales/zh-CN/app.po
+++ b/locales/zh-CN/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-20 02:54+0000\n"
 "Last-Translator: 우믿트 <eloli@foxmail.com>\n"
 "Language: zh_Hans_CN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -136,11 +136,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "隐私声明"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -449,16 +455,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/zh-TW/app.po
+++ b/locales/zh-TW/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-05 21:56+0800\n"
+"POT-Creation-Date: 2019-03-07 15:42+0800\n"
 "PO-Revision-Date: 2019-02-23 06:58+0000\n"
 "Last-Translator: elin <elin@mozilla.com>\n"
 "Language: zh_Hant_TW\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.4.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -136,11 +136,17 @@ msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "隱私權公告"
 
+#. Life Feed is an information panel covering content that might help our
+#. customers' life. It covers from the most popular topics to the hottest
+#. deals, including news, games, coupon...etc.
 msgctxt "life_feed"
 msgid "Life Feed"
 msgstr ""
 
-#. The %1$s here is a placeholder for "Life Feed"
+#. The %1$s here is a placeholder for "Life Feed". Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "about_link_life_feed"
 msgid "Learn more about %1$s"
@@ -449,16 +455,15 @@ msgid "Discover new things"
 msgstr ""
 
 #. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
-#. which is localized in lifefeed_learn_more
+#. which is localized in preference_learn_more. Life Feed is an information
+#. panel covering content that might help our customers' life. It covers from
+#. the most popular topics to the hottest deals, including news, games,
+#. coupon...etc.
 #, c-format
 msgctxt "first_run_page6_text"
 msgid ""
 "Just one flip, keep yourself updated with the “%1$s” - a variety of "
 "contents from the most popular topics to the hottest deals. %2$s"
-msgstr ""
-
-msgctxt "lifefeed_learn_more"
-msgid "Learn more"
 msgstr ""
 
 msgctxt "first_run_upgrade_page_title"

--- a/locales/zh-TW/app.po
+++ b/locales/zh-TW/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-18 16:57+0800\n"
+"POT-Creation-Date: 2019-03-05 21:56+0800\n"
 "PO-Revision-Date: 2019-02-23 06:58+0000\n"
 "Last-Translator: elin <elin@mozilla.com>\n"
+"Language: zh_Hant_TW\n"
 "Language-Team: zh_Hant_TW <LL@li.org>\n"
-"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.6.0\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -116,7 +115,9 @@ msgstr "在 Firefox Lite 中搜尋"
 #. Firefox Rocket     %2$s is "Mozilla"
 #, c-format
 msgctxt "about_content_body"
-msgid "%1$s is a fast and lightweight browser produced by %2$s. Our mission is to foster a healthy, open internet."
+msgid ""
+"%1$s is a fast and lightweight browser produced by %2$s. Our mission is "
+"to foster a healthy, open internet."
 msgstr "%1$s 是由 %2$s 所打造的輕量而快速的瀏覽器。我們的使命是培養一個健康、開放的網際網路環境。"
 
 msgctxt "about_link_learn_more"
@@ -134,6 +135,16 @@ msgstr "您的權利 / 授權條款"
 msgctxt "about_link_privacy"
 msgid "Privacy Notice"
 msgstr "隱私權公告"
+
+msgctxt "life_feed"
+msgid "Life Feed"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed"
+#, c-format
+msgctxt "about_link_life_feed"
+msgid "Learn more about %1$s"
+msgstr ""
 
 #. This label is shown below the name of the default search engine in settings
 msgctxt "preference_search_engine_default"
@@ -154,6 +165,11 @@ msgstr "系統預設"
 msgctxt "preference_dialog_title_search_engine"
 msgid "Default search engine"
 msgstr "預設搜尋引擎"
+
+#. This is the title of the dialog for choosing news source
+msgctxt "preference_dialog_title_news_source"
+msgid "News source"
+msgstr ""
 
 msgctxt "preference_data_saving_block_images"
 msgid "Block images"
@@ -196,7 +212,9 @@ msgstr "傳送使用資料"
 #. Parameter %1$s is the app name, i.e. Firefox Rocket.     %2$s is "Mozilla"
 #, c-format
 msgctxt "preference_mozilla_telemetry_summary"
-msgid "%2$s strives to collect only what we need to provide and improve %1$s for everyone."
+msgid ""
+"%2$s strives to collect only what we need to provide and improve %1$s for"
+" everyone."
 msgstr "%2$s 致力於只收集用來為眾人改善 %1$s 所需的必要資料。"
 
 msgctxt "preference_learn_more"
@@ -307,7 +325,9 @@ msgstr "尋找可開啟此鏈結的應用程式"
 #. that's Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "您裝置中並未安裝可開啟此鏈結的應用程式。您可離開 %1$s，到 %2$s 安裝一套。"
 
 #. The page html title (i.e. the <title> tag content)
@@ -389,7 +409,9 @@ msgid "Browse faster than ever"
 msgstr "上網變得更快"
 
 msgctxt "first_run_page2_text"
-msgid "Use turbo mode to block tracking ads so you can browse at blazing speeds. If sites seem broken, just tap off the turbo mode switch in the menu."
+msgid ""
+"Use turbo mode to block tracking ads so you can browse at blazing speeds."
+" If sites seem broken, just tap off the turbo mode switch in the menu."
 msgstr "使用極速模式來封鎖追蹤廣告，這樣就可以用更快的速度上網。若網站用起來有問題，只要在選單暫時關閉即可。"
 
 msgctxt "first_run_page3_title"
@@ -397,7 +419,9 @@ msgid "Save data = Save money"
 msgstr "節省流量 就是省錢"
 
 msgctxt "first_run_page3_text"
-msgid "Save on data costs by blocking tracking ads. Save even more when you enable image blocking."
+msgid ""
+"Save on data costs by blocking tracking ads. Save even more when you "
+"enable image blocking."
 msgstr "透過封鎖追蹤廣告來節省上網流量，若封鎖圖片顯示還可節省更多。"
 
 msgctxt "first_run_page4_title"
@@ -405,7 +429,9 @@ msgid "Screenshot the whole page"
 msgstr "拍攝整張頁面的擷圖"
 
 msgctxt "first_run_page4_text"
-msgid "Take screenshot of an entire page scroll. Read it offline without using data or tap it to revisit the web page."
+msgid ""
+"Take screenshot of an entire page scroll. Read it offline without using "
+"data or tap it to revisit the web page."
 msgstr "拍攝整個頁面的長條擷圖，儲存後即可離線閱讀，之後不用再耗費流量或點擊重新開啟。"
 
 msgctxt "first_run_page5_title"
@@ -413,8 +439,27 @@ msgid "Next-level privacy"
 msgstr "更進一步的隱私保護"
 
 msgctxt "first_run_page5_text"
-msgid "Browse without a trace, and block a wide range of common web trackers by default. Ensure the security of your confidential data."
+msgid ""
+"Browse without a trace, and block a wide range of common web trackers by "
+"default. Ensure the security of your confidential data."
 msgstr "瀏覽不留痕跡，還會預設封鎖一系列常見的網頁追蹤器，可確保您的機密資料安全。"
+
+msgctxt "first_run_page6_title"
+msgid "Discover new things"
+msgstr ""
+
+#. The %1$s here is a placeholder for "Life Feed", the %2$s is "Learn more"
+#. which is localized in lifefeed_learn_more
+#, c-format
+msgctxt "first_run_page6_text"
+msgid ""
+"Just one flip, keep yourself updated with the “%1$s” - a variety of "
+"contents from the most popular topics to the hottest deals. %2$s"
+msgstr ""
+
+msgctxt "lifefeed_learn_more"
+msgid "Learn more"
+msgstr ""
 
 msgctxt "first_run_upgrade_page_title"
 msgid "We heard your feedback!"
@@ -427,7 +472,9 @@ msgstr "我們有全新外觀！"
 #. The %1$s here is a placeholder for "Firefox Lite"
 #, c-format
 msgctxt "new_name_upgrade_page_text"
-msgid "With the evolved product, we bring you a newly refreshed %1$s, with new name and new logo."
+msgid ""
+"With the evolved product, we bring you a newly refreshed %1$s, with new "
+"name and new logo."
 msgstr "隨著產品不斷進化，我們推出全新的 %1$s，改為新的名稱也更換商標。"
 
 #. The %s here is a placeholder for "multiple tabs" (paired with
@@ -548,7 +595,9 @@ msgid "Location not available. Give permission to access your location."
 msgstr "無法取得所在位置，請授權取得您的所在位置。"
 
 msgctxt "permission_toast_storage"
-msgid "Storage not available. Give permission to store photos and files on your device."
+msgid ""
+"Storage not available. Give permission to store photos and files on your "
+"device."
 msgstr "儲存空間無法使用，請授權儲存照片與檔案到您的裝置。"
 
 #. When the webpage request access to geolocation a dialog will popup.
@@ -932,7 +981,9 @@ msgid "Product Update Notice"
 msgstr "產品更新公告"
 
 msgctxt "privacy_policy_update_notification_action"
-msgid "To make Firefox Lite better for you and everyone, we made some changes to our privacy policy. Tap to learn more."
+msgid ""
+"To make Firefox Lite better for you and everyone, we made some changes to"
+" our privacy policy. Tap to learn more."
 msgstr "為了讓 Firefox Lite 能為您與所有人變得更好，我們修改了部分的隱私權保護政策。可點擊此處了解更多資訊。"
 
 #. In-app Promotion, Rate the App
@@ -1003,7 +1054,9 @@ msgstr "%1$s 是由 %2$s 及其貢獻者所打造，自由且開放原始碼的�
 #. linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)     %3$s will
 #. be replaced by "Mozilla Public License"
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">%3$s</a> and other open source licenses."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">%3$s</a> and other open source licenses."
 msgstr "%1$s 是依照 <a href=\"%2$s\">%3$s</a> 以及其他開放原始碼授權條款提供給您。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
@@ -1013,15 +1066,20 @@ msgstr "%1$s 是依照 <a href=\"%2$s\">%3$s</a> 以及其他開放原始碼授�
 #. replaced by "Mozilla"     %4$s will be replaced by "Firefox"
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names or logos. Additional information may be found <a "
-"href=\"%2$s\">here</a>."
-msgstr "您並未被授權使用 Mozilla 基金會或任何相關部門的商標，包含但不限於 %3$s、%4$s、%1$s 的文字或圖樣。您可以在<a href=\"%2$s\">這裡</a>找到更多資訊。"
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the %3$s, %4$s or %1$s names "
+"or logos. Additional information may be found <a href=\"%2$s\">here</a>."
+msgstr ""
+"您並未被授權使用 Mozilla 基金會或任何相關部門的商標，包含但不限於 %3$s、%4$s、%1$s 的文字或圖樣。您可以在<a "
+"href=\"%2$s\">這裡</a>找到更多資訊。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox Rocket)     %2$s will be replaced with a URL
 #. linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
 msgstr "%1$s 其他部分的原始碼，則使用各種不同的自由與開放原始碼<a href=\"%2$s\">授權條款</a>提供。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
@@ -1030,8 +1088,13 @@ msgstr "%1$s 其他部分的原始碼，則使用各種不同的自由與開放�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s 還使用由 Disconnect, Inc. 提供的封鎖清單，該清單是一份依照 <a href=\"%2$s\">GNU General Public License v3</a> 提供的獨立作品，可在<a href=\"%3$s\">此處</a>取得。"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s 還使用由 Disconnect, Inc. 提供的封鎖清單，該清單是一份依照 <a href=\"%2$s\">GNU General "
+"Public License v3</a> 提供的獨立作品，可在<a href=\"%3$s\">此處</a>取得。"
 
 #. Title for survey notification posted after launching the app on the 3rd
 #. time     %1$s will be replaced with an emoticon
@@ -1201,14 +1264,18 @@ msgstr "在此檢視您的擷圖！"
 #. The notice shown along with the message when the user captures screenshot
 #. for the first time
 msgctxt "my_shot_on_boarding_category_message"
-msgid "To improve your product experience, we collect information about your screenshots’ categories."
+msgid ""
+"To improve your product experience, we collect information about your "
+"screenshots’ categories."
 msgstr "為了改善產品使用體驗，我們會收集您拍攝的擷圖分類。"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
 #. want this feature or not. Press "Yes, please" then direct users to download
 #. vpn app; Press "Nope" then hide the icon in home screen.
 msgctxt "btn_vpn"
-msgid "The 7-day free VPN service is ready for you. Install now to browse more privately and securely."
+msgid ""
+"The 7-day free VPN service is ready for you. Install now to browse more "
+"privately and securely."
 msgstr "免費的 7 天試用 VPN 服務已經準備好了，現在安裝即可更私密、更安全地上網。"
 
 #. Message shown in Home Screen with an icon. Users can choose either they
@@ -1216,7 +1283,8 @@ msgstr "免費的 7 天試用 VPN 服務已經準備好了，現在安裝即可�
 #. feature base on the users' feedback.
 msgctxt "exp_survey_wifi"
 msgid ""
-"We plan to integrate “Free Wifi-Finder” to help you find quality free internet connection nearby.\n"
+"We plan to integrate “Free Wifi-Finder” to help you find quality free "
+"internet connection nearby.\n"
 "\n"
 " Interested?"
 msgstr ""
@@ -1229,7 +1297,8 @@ msgstr ""
 #. feature base on the users' feedback.
 msgctxt "exp_survey_vpn"
 msgid ""
-"We plan to integrate “VPN service” to get you more freedom and more privacy when browsing.\n"
+"We plan to integrate “VPN service” to get you more freedom and more "
+"privacy when browsing.\n"
 "\n"
 " Interested?"
 msgstr ""
@@ -1255,3 +1324,4 @@ msgstr "好的，謝謝"
 msgctxt "exp_survey_no"
 msgid "NOPE"
 msgstr "不要"
+


### PR DESCRIPTION
l10n for Rocket Pinatubo
See here for the [schedule](https://github.com/mozilla-tw/FirefoxLite/wiki/Release-Schedule) of the release.
Related issues on Rocket:
Adding [6 strings](https://github.com/mozilla-tw/FirefoxLite/commit/7f938bf2ad1ca386188bd4ecaefe3701e0d181df) for [Content Portal Onboarding + Setting](https://github.com/mozilla-tw/FirefoxLite/issues/3173)
